### PR TITLE
Create a Command Bus Component

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-poetry run coverage run -m pytest tests "$@"
+poetry run coverage run -m pytest --xdoctest "$@"
 poetry run coverage report
 poetry run mypy src tests
 poetry run ruff .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ tests = ["tests", "*/tests"]
 [tool.coverage.run]
 branch = true
 source = ["boss_bus", "tests"]
+omit = [
+    "tests/examples.py",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ tests = ["tests", "*/tests"]
 branch = true
 source = ["boss_bus", "tests"]
 omit = [
+    "src/boss_bus/_utils/*",
     "tests/examples.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boss-bus"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Type-driven Message Bus for Python 3.8+"
 authors = ["Jim Dickinson <james.n.dickinson@gmail.com>"]
 license = "GPL-3.0"
@@ -10,6 +10,13 @@ repository = "https://github.com/jimbroze/boss-bus"
 documentation = "https://boss-bus.readthedocs.io"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 
 [tool.poetry.urls]

--- a/src/boss_bus/_utils/__init__.py
+++ b/src/boss_bus/_utils/__init__.py
@@ -1,0 +1,3 @@
+"""Internal Utility functions."""
+
+# from .typing import get_annotations, type_matches

--- a/src/boss_bus/_utils/typing.py
+++ b/src/boss_bus/_utils/typing.py
@@ -5,10 +5,14 @@ import sys
 import types
 
 try:
-    from types import UnionType as Union  # type: ignore[attr-defined]
+    from types import (  # type: ignore[attr-defined, unused-ignore]
+        UnionType as _Union,
+    )
 except ImportError:
-    from typing import Union
-from typing import Any, Mapping, get_args, get_origin
+    from typing import (  # type: ignore[assignment, unused-ignore]
+        Union as _Union,
+    )
+from typing import Any, Mapping, Union, get_args, get_origin
 
 
 def get_annotations(
@@ -24,9 +28,16 @@ def get_annotations(
     Otherwise, uses the back-ported function in this module.
     """
     try:
-        from inspect import get_annotations  # type: ignore[attr-defined]
+        from inspect import (  # type: ignore[attr-defined, unused-ignore]
+            get_annotations,
+        )
 
-        return get_annotations(obj, globals=globals, locals=locals, eval_str=eval_str)  # type: ignore[no-any-return]
+        return get_annotations(  # type: ignore[no-any-return, unused-ignore]
+            obj,  # type: ignore[arg-type, unused-ignore]
+            globals=globals,
+            locals=locals,
+            eval_str=eval_str,
+        )
     except ImportError:
         return _get_annotations(
             obj, _globals=globals, _locals=locals, eval_str=eval_str
@@ -48,7 +59,7 @@ def _eval_annotations(
     if len(evals) == 1:
         return evals[0]
 
-    return Union[tuple(evals)]
+    return Union[tuple(evals)]  # type: ignore[misc, unused-ignore]
 
 
 def _get_annotations(  # noqa C901
@@ -148,7 +159,7 @@ def type_matches(expected: type, actual: type) -> bool:
     if expected == actual:
         return True
 
-    if get_origin(expected) is Union:
+    if get_origin(expected) is Union or get_origin(expected) is _Union:
         for sub_type in get_args(expected):
             if sub_type == actual:
                 return True

--- a/src/boss_bus/_utils/typing.py
+++ b/src/boss_bus/_utils/typing.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import functools
+import sys
+import types
+
+try:
+    from types import UnionType as Union  # type: ignore[attr-defined]
+except ImportError:
+    from typing import Union
+from typing import Any, Mapping, get_args, get_origin
+
+
+def get_annotations(
+    obj: object | type | types.ModuleType,
+    *,
+    globals: dict[str, Any] | None = None,  # noqa A002
+    locals: Mapping[str, Any] | None = None,  # noqa A002
+    eval_str: bool = True,
+) -> dict[str, Any]:
+    """Compute the annotations dict for an object.
+
+    Tries to use the standard inspect package if available (>Python 3.10)
+    Otherwise, uses the back-ported function in this module.
+    """
+    try:
+        from inspect import get_annotations  # type: ignore[attr-defined]
+
+        return get_annotations(obj, globals=globals, locals=locals, eval_str=eval_str)  # type: ignore[no-any-return]
+    except ImportError:
+        return _get_annotations(
+            obj, _globals=globals, _locals=locals, eval_str=eval_str
+        )
+
+
+def _eval_annotations(
+    value: Any, _globals: dict[str, Any] | None, _locals: Mapping[str, object] | None
+) -> Any:
+    def _eval(_value: Any) -> Any:
+        try:
+            return eval(_value, _globals, _locals)  # noqa S307
+        except:  # noqa E722
+            return _value
+
+    values = value.split(" | ")
+    evals = [_eval(value) for value in values]
+
+    if len(evals) == 1:
+        return evals[0]
+
+    return Union[tuple(evals)]
+
+
+def _get_annotations(  # noqa C901
+    obj: object | type | types.ModuleType,
+    *,
+    _globals: dict[str, Any] | None = None,
+    _locals: Mapping[str, Any] | None = None,
+    eval_str: bool,
+) -> dict[str, Any]:
+    """Compute the annotations dict for an object.
+
+    This function is back-ported from Python 3.10.
+    See https://docs.python.org/3/howto/annotations.html
+    and https://docs.python.org/3/library/inspect.html#inspect.get_annotations
+
+    """
+    if isinstance(obj, type):
+        # class
+        obj_dict = getattr(obj, "__dict__", None)
+        if obj_dict and hasattr(obj_dict, "get"):
+            ann = obj_dict.get("__annotations__", None)
+            if isinstance(ann, types.GetSetDescriptorType):
+                ann = None
+        else:
+            ann = None
+
+        obj_globals = None
+        module_name = getattr(obj, "__module__", None)
+        if module_name:
+            module = sys.modules.get(module_name, None)
+            if module:
+                obj_globals = getattr(module, "__dict__", None)
+        obj_locals = dict(vars(obj))
+        unwrap: object = obj
+    elif isinstance(obj, types.ModuleType):
+        # module
+        ann = getattr(obj, "__annotations__", None)
+        obj_globals = getattr(obj, "__dict__", None)
+        obj_locals = None
+        unwrap = None
+    elif callable(obj):
+        # this includes types.Function, types.BuiltinFunctionType,
+        # types.BuiltinMethodType, functools.partial, functools.singledispatch,
+        # etc etc etc...
+        ann = getattr(obj, "__annotations__", None)
+        obj_globals = getattr(obj, "__globals__", None)
+        obj_locals = None
+        unwrap = obj
+    else:
+        raise TypeError(f"{obj!r} is not a module, class, or callable.")
+
+    if ann is None:
+        return {}
+
+    if not isinstance(ann, dict):
+        raise ValueError(f"{obj!r}.__annotations__ is neither a dict nor None")
+
+    if not ann or not eval_str:
+        return ann
+
+    if unwrap is not None:
+        while True:
+            if hasattr(unwrap, "__wrapped__"):
+                unwrap = unwrap.__wrapped__
+                continue
+            if isinstance(unwrap, functools.partial):
+                unwrap = unwrap.func
+                continue
+            break
+        if hasattr(unwrap, "__globals__"):
+            obj_globals = unwrap.__globals__
+
+    eval_globals: dict[str, Any] | None = obj_globals if _globals is None else _globals
+
+    if _locals is None:
+        _locals = obj_locals
+
+    return {
+        key: value
+        if not isinstance(value, str)
+        else _eval_annotations(value, eval_globals, _locals)
+        for key, value in ann.items()
+    }
+
+
+def type_matches(expected: type, actual: type) -> bool:
+    """Checks if a class matches an expected result.
+
+    This includes checking if the actual class is in a Union with other classes.
+
+    Example:
+        >>> expected_class = Union[str, int]
+        >>> actual_class = str
+        >>> type_matches(expected_class, actual_class)
+        True
+    """
+    if expected == actual:
+        return True
+
+    if get_origin(expected) is Union:
+        for sub_type in get_args(expected):
+            if sub_type == actual:
+                return True
+
+    return False

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -17,7 +17,7 @@ from typing import Any, Generic, Type, TypeVar
 from typeguard import typechecked
 
 from boss_bus.handler import MissingHandlerError
-from boss_bus.interface import IMessageHandler
+from boss_bus.interface import SupportsHandle
 
 
 class Command:
@@ -27,7 +27,7 @@ class Command:
 SpecificCommand = TypeVar("SpecificCommand", bound=Command)
 
 
-class CommandHandler(ABC, IMessageHandler, Generic[SpecificCommand]):
+class CommandHandler(ABC, SupportsHandle, Generic[SpecificCommand]):
     """A form of message which only has one handler."""
 
     @abstractmethod

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -1,0 +1,69 @@
+"""Interfaces for a form of message bus that executes commands.
+
+Commands can only have one handler.
+
+Classes:
+
+    Command
+    CommandBus
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+from typeguard import typechecked
+
+from boss_bus.handler import MissingHandlerError
+
+if TYPE_CHECKING:
+    from boss_bus.interface import IMessageHandler
+
+
+class Command:
+    """A form of message which only has one handler."""
+
+
+class MissingCommandError(Exception):
+    """The requested Error could not be found."""
+
+
+class TooManyHandlersError(Exception):
+    """Only one handler can be used with a command."""
+
+
+class CommandBus:
+    """Executes commands using their associated handler."""
+
+    def __init__(self) -> None:
+        """Creates a Command Bus."""
+        self._handlers: dict[type[Command], IMessageHandler] = {}
+
+    @typechecked
+    def register_handler(
+        self,
+        command_type: Type[Command],  # noqa: UP006
+        handler: IMessageHandler,
+    ) -> None:
+        """Register a single handler that will execute a type of Command."""
+        self._handlers[command_type] = handler
+
+    @typechecked
+    def execute(self, command: Command, handler: IMessageHandler | None = None) -> None:
+        """Execute a provided command using its handler."""
+        if hasattr(handler, "__iter__"):
+            raise TooManyHandlersError("Only one handler can execute a command")
+
+        matched_handler = self._handlers.get(type(command), handler)
+
+        if handler and handler != matched_handler:
+            raise TooManyHandlersError(
+                f"A handler has already been registered for the command '{type(command).__name__}'"
+            )
+
+        if not matched_handler:
+            raise MissingHandlerError(
+                f"A handler has not been registered for the command '{type(command).__name__}'"
+            )
+
+        matched_handler.handle(command)

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -45,9 +45,8 @@ class InvalidHandlerError(Exception):
 
 
 def _validate_handler(
-    command_type: type[Command], handler: CommandHandler[Any]
+    command_type: Type[Command], handler: CommandHandler[Any]  # noqa UP006
 ) -> None:
-    # not in signature(handler.handle).parameters["command"].annotation
     if not type_matches(get_annotations(handler.handle)["command"], command_type):
         raise InvalidHandlerError(
             f"The handler '{handler}' does not match the command '{command_type.__name__}'"

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -50,7 +50,9 @@ def _validate_handler(
         command_type.__name__
         != signature(handler.handle).parameters["command"].annotation
     ):
-        raise InvalidHandlerError
+        raise InvalidHandlerError(
+            f"The handler '{handler}' does not match the command '{command_type.__name__}'"
+        )
 
 
 class CommandBus:
@@ -70,6 +72,19 @@ class CommandBus:
         _validate_handler(command_type, handler)
 
         self._handlers[command_type] = handler
+
+    @typechecked
+    def remove_handler(
+        self,
+        command_type: Type[SpecificCommand],  # noqa: UP006
+    ) -> None:
+        """Remove a previously registered handler."""
+        if command_type not in self._handlers:
+            raise MissingHandlerError(
+                f"A handler has not been registered for the command '{command_type.__name__}'"
+            )
+
+        del self._handlers[command_type]
 
     @typechecked
     def execute(

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -38,14 +38,14 @@ class EventBus:
     """Dispatches events to their associated handlers.
 
     Example:
-            >>> from tests.examples import TestEvent, TestEventHandler
-            >>> bus = EventBus()
-            >>> handler = TestEventHandler()
-            >>> event = TestEvent("Testing...")
-            >>>
-            >>> bus.add_handlers(TestEvent, [handler])
-            >>> bus.dispatch(event)
-            Testing...
+        >>> from tests.examples import TestEvent, TestEventHandler
+        >>> bus = EventBus()
+        >>> test_handler = TestEventHandler()
+        >>> test_event = TestEvent("Testing...")
+        >>>
+        >>> bus.add_handlers(TestEvent, [test_handler])
+        >>> bus.dispatch(test_event)
+        Testing...
     """
 
     def __init__(self) -> None:
@@ -92,7 +92,17 @@ class EventBus:
     ) -> None:
         """Dispatch events to their handlers.
 
+        Handlers can be dispatched directly or pre-registered with 'add_handlers'.
         Previously registered handlers dispatch first.
+
+        Example:
+            >>> from tests.examples import TestEvent, TestEventHandler
+            >>> bus = EventBus()
+            >>> test_handler = TestEventHandler()
+            >>> test_event = TestEvent("Testing...")
+            >>>
+            >>> bus.dispatch(test_event, [test_handler])
+            Testing...
         """
         if handlers is None:
             handlers = []

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -58,9 +58,6 @@ class EventBus:
         if handlers is None:
             handlers = []
 
-        if event_type not in self._handlers:
-            raise MissingEventError(f"The event '{event_type}' has not been registered")
-
         for handler in handlers:
             if handler not in self._handlers[event_type]:
                 raise MissingHandlerError(
@@ -69,10 +66,8 @@ class EventBus:
 
             self._handlers[event_type].remove(handler)
 
-        if (  # pragma: no branch
-            len(handlers) == 0 or len(self._handlers[event_type]) == 0
-        ):
-            del self._handlers[event_type]
+        if len(handlers) == 0:  # pragma: no branch
+            self._handlers[event_type] = []
 
     @typechecked
     def dispatch(

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -11,7 +11,7 @@ Classes:
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Sequence, Type
 
 from typeguard import typechecked
 
@@ -38,7 +38,9 @@ class EventBus:
 
     @typechecked
     def add_handlers(
-        self, event_type: Type[Event], handlers: list[IMessageHandler]  # noqa: UP006
+        self,
+        event_type: Type[Event],  # noqa: UP006
+        handlers: Sequence[IMessageHandler],
     ) -> None:
         """Register handlers that will dispatch a type of Event."""
         if len(handlers) == 0:
@@ -50,7 +52,7 @@ class EventBus:
     def remove_handlers(
         self,
         event_type: Type[Event],  # noqa: UP006
-        handlers: list[IMessageHandler] | None = None,
+        handlers: Sequence[IMessageHandler] | None = None,
     ) -> None:
         """Remove previously registered handlers."""
         if handlers is None:
@@ -74,14 +76,17 @@ class EventBus:
 
     @typechecked
     def dispatch(
-        self, event: Event, handlers: list[IMessageHandler] | None = None
+        self, event: Event, handlers: Sequence[IMessageHandler] | None = None
     ) -> None:
-        """Dispatch a provided event to the given handlers."""
+        """Dispatch events to their handlers.
+
+        Previously registered handlers dispatch first.
+        """
         if handlers is None:
             handlers = []
 
         matched_handlers = self._handlers[type(event)]
-        handlers.extend(matched_handlers)
+        matched_handlers.extend(handlers)
 
-        for handler in handlers:  # pragma: no branch
+        for handler in matched_handlers:  # pragma: no branch
             handler.handle(event)

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -30,7 +30,18 @@ class MissingEventError(Exception):
 
 
 class EventBus:
-    """Dispatches events to their associated handlers."""
+    """Dispatches events to their associated handlers.
+
+    Example:
+            >>> from tests.examples import TestEvent, TestEventHandler
+            >>> bus = EventBus()
+            >>> handler = TestEventHandler()
+            >>> event = TestEvent("Testing...")
+            >>>
+            >>> bus.add_handlers(TestEvent, [handler])
+            >>> bus.dispatch(event)
+            Testing...
+    """
 
     def __init__(self) -> None:
         """Creates an Event Bus."""

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -62,7 +62,7 @@ class EventBus:
         for handler in handlers:
             if handler not in self._handlers[event_type]:
                 raise MissingHandlerError(
-                    f"The handler '{handler}' has not been registered for event '{event_type}'"
+                    f"The handler '{handler}' has not been registered for event '{event_type.__name__}'"
                 )
 
             self._handlers[event_type].remove(handler)

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Sequence, Type
 
-from typeguard import typechecked
+from typeguard import TypeCheckError, typechecked
 
 from boss_bus.handler import MissingHandlerError
 from boss_bus.interface import SupportsHandle
@@ -29,7 +29,9 @@ class MissingEventError(Exception):
 
 def _validate_handler(handler: Any) -> None:
     if isinstance(handler, type):
-        raise TypeError(f"'handlers' must be an instance of {SupportsHandle.__name__}")
+        raise TypeCheckError(
+            f"'handlers' must be an instance of {SupportsHandle.__name__}"
+        )
 
 
 class EventBus:
@@ -57,9 +59,6 @@ class EventBus:
         handlers: Sequence[SupportsHandle],
     ) -> None:
         """Register handlers that will dispatch a type of Event."""
-        if len(handlers) == 0:
-            raise TypeError("add_handlers() requires at least one handler")
-
         for handler in handlers:  # pragma: no branch
             _validate_handler(handler)
             self._handlers[event_type].append(handler)

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -28,7 +28,7 @@ class MissingEventError(Exception):
 
 
 def _validate_handler(handler: Any) -> None:
-    if not isinstance(handler, IMessageHandler) or isinstance(handler, type):
+    if isinstance(handler, type):
         raise TypeError(f"'handlers' must be an instance of {IMessageHandler.__name__}")
 
 

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -16,7 +16,7 @@ from typing import Any, Sequence, Type
 from typeguard import typechecked
 
 from boss_bus.handler import MissingHandlerError
-from boss_bus.interface import IMessageHandler
+from boss_bus.interface import SupportsHandle
 
 
 class Event:
@@ -29,7 +29,7 @@ class MissingEventError(Exception):
 
 def _validate_handler(handler: Any) -> None:
     if isinstance(handler, type):
-        raise TypeError(f"'handlers' must be an instance of {IMessageHandler.__name__}")
+        raise TypeError(f"'handlers' must be an instance of {SupportsHandle.__name__}")
 
 
 class EventBus:
@@ -48,13 +48,13 @@ class EventBus:
 
     def __init__(self) -> None:
         """Creates an Event Bus."""
-        self._handlers: dict[type[Event], list[IMessageHandler]] = defaultdict(list)
+        self._handlers: dict[type[Event], list[SupportsHandle]] = defaultdict(list)
 
     @typechecked
     def add_handlers(
         self,
         event_type: Type[Event],  # noqa: UP006
-        handlers: Sequence[IMessageHandler],
+        handlers: Sequence[SupportsHandle],
     ) -> None:
         """Register handlers that will dispatch a type of Event.
 
@@ -79,7 +79,7 @@ class EventBus:
     def remove_handlers(
         self,
         event_type: Type[Event],  # noqa: UP006
-        handlers: Sequence[IMessageHandler] | None = None,
+        handlers: Sequence[SupportsHandle] | None = None,
     ) -> None:
         """Remove previously registered handlers."""
         if handlers is None:
@@ -100,7 +100,7 @@ class EventBus:
 
     @typechecked
     def dispatch(
-        self, event: Event, handlers: Sequence[IMessageHandler] | None = None
+        self, event: Event, handlers: Sequence[SupportsHandle] | None = None
     ) -> None:
         """Dispatch events to their handlers.
 

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -56,18 +56,7 @@ class EventBus:
         event_type: Type[Event],  # noqa: UP006
         handlers: Sequence[SupportsHandle],
     ) -> None:
-        """Register handlers that will dispatch a type of Event.
-
-        Example:
-            >>> from tests.examples import TestEvent, TestEventHandler
-            >>> bus = EventBus()
-            >>> handler = TestEventHandler()
-            >>> event = TestEvent("Testing...")
-            >>>
-            >>> bus.add_handlers(TestEvent, [handler])
-            >>> bus.
-            Testing...
-        """
+        """Register handlers that will dispatch a type of Event."""
         if len(handlers) == 0:
             raise TypeError("add_handlers() requires at least one handler")
 

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Type
 
 from typeguard import typechecked
 
+from boss_bus.handler import MissingHandlerError
+
 if TYPE_CHECKING:
     from boss_bus.interface import IMessageHandler
 
@@ -25,10 +27,6 @@ class Event:
 
 class MissingEventError(Exception):
     """The requested Error could not be found."""
-
-
-class MissingHandlerError(Exception):
-    """The requested Handler could not be found."""
 
 
 class EventBus:

--- a/src/boss_bus/handler.py
+++ b/src/boss_bus/handler.py
@@ -1,0 +1,7 @@
+"""Base Message Handler classes."""
+
+from __future__ import annotations
+
+
+class MissingHandlerError(Exception):
+    """The requested Handler could not be found."""

--- a/src/boss_bus/interface.py
+++ b/src/boss_bus/interface.py
@@ -7,9 +7,10 @@ Classes:
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
+@runtime_checkable
 class IMessageHandler(Protocol):
     """An interface that requires a handler method."""
 

--- a/src/boss_bus/interface.py
+++ b/src/boss_bus/interface.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
-class IMessageHandler(Protocol):
+class SupportsHandle(Protocol):
     """An interface that requires a handler method."""
 
     def handle(self, message: Any) -> Any:

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,3 +1,4 @@
+from boss_bus.command_bus import Command, CommandHandler
 from boss_bus.event_bus import Event
 from boss_bus.interface import SupportsHandle
 
@@ -19,3 +20,22 @@ class TestEventHandler(SupportsHandle):
     def handle(self, event: TestEvent) -> None:
         """Handle a test event."""
         event.print_event_data()
+
+
+class TestCommand(Command):
+    """A type of command purely for use in tests."""
+
+    def __init__(self, command_data: str):
+        """Creates a command for tests."""
+        self.command_data = command_data
+
+    def print_command_data(self) -> None:
+        print(self.command_data)
+
+
+class TestCommandHandler(CommandHandler[TestCommand]):
+    """A command handler purely for use in tests."""
+
+    def handle(self, command: TestCommand) -> None:
+        """Handle a test command."""
+        command.print_command_data()

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,5 +1,5 @@
 from boss_bus.event_bus import Event
-from boss_bus.interface import IMessageHandler
+from boss_bus.interface import SupportsHandle
 
 
 class TestEvent(Event):
@@ -13,7 +13,7 @@ class TestEvent(Event):
         print(self.event_data)
 
 
-class TestEventHandler(IMessageHandler):
+class TestEventHandler(SupportsHandle):
     """An event handler purely for use in tests."""
 
     def handle(self, event: TestEvent) -> None:

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,0 +1,21 @@
+from boss_bus.event_bus import Event
+from boss_bus.interface import IMessageHandler
+
+
+class TestEvent(Event):
+    """A type of event purely for use in tests."""
+
+    def __init__(self, event_data: str):
+        """Creates an event for tests."""
+        self.event_data = event_data
+
+    def print_event_data(self) -> None:
+        print(self.event_data)
+
+
+class TestEventHandler(IMessageHandler):
+    """An event handler purely for use in tests."""
+
+    def handle(self, event: TestEvent) -> None:
+        """Handle a test event."""
+        event.print_event_data()

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -143,3 +143,24 @@ class TestCommandBus:
 
         with pytest.raises(TypeCheckError):
             bus.register_handler(command, [handler1, handler2])  # type: ignore[arg-type]
+
+    def test_remove_handler_removes_handler_for_a_given_command_and_deletes_key(
+        self,
+    ) -> None:
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.register_handler(ExplosionCommand, handler)
+        assert ExplosionCommand in bus._handlers  # noqa: SLF001
+
+        bus.remove_handler(ExplosionCommand)
+
+        assert ExplosionCommand not in bus._handlers  # noqa: SLF001
+
+    def test_remove_handler_throws_exception_if_command_is_not_registered(
+        self,
+    ) -> None:
+        bus = CommandBus()
+
+        with pytest.raises(MissingHandlerError):
+            bus.remove_handler(ExplosionCommand)

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -38,6 +38,11 @@ class UnionCommandHandler(CommandHandler[Union[ExplosionCommand, FloodCommand]])
         command.print_command_data()
 
 
+# class UnionCommandHandler(CommandHandler[Union[ExplosionCommand, FloodCommand]]):
+#     def handle(self, command: ExplosionCommand | FloodCommand) -> None:
+#         command.print_command_data()
+
+
 class ExplosionCommandHandler(CommandHandler[ExplosionCommand]):
     def handle(self, command: ExplosionCommand) -> None:
         command.print_command_data()

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -65,7 +65,7 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(InvalidHandlerError):
-            bus.execute(command, handler)  # type: ignore
+            bus.execute(command, handler)  # type: ignore[misc]
 
     def test_execute_does_not_accept_multiple_handlers(self) -> None:
         command = ExplosionCommand()
@@ -74,7 +74,7 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(TypeCheckError):
-            bus.execute(command, [handler1, handler2])  # type: ignore
+            bus.execute(command, [handler1, handler2])  # type: ignore[arg-type]
 
     def test_execute_cannot_execute_a_command_with_no_handlers(
         self,
@@ -116,7 +116,7 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(TypeError):
-            bus.register_handler(ExplosionCommand)  # type: ignore
+            bus.register_handler(ExplosionCommand)  # type: ignore[call-arg]
 
     def test_register_handler_requires_command_type_to_be_a_type(self) -> None:
         command = ExplosionCommand()
@@ -124,7 +124,7 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(TypeCheckError):
-            bus.register_handler(command, handler1)  # type: ignore
+            bus.register_handler(command, handler1)  # type: ignore[arg-type]
 
     def test_register_handler_will_not_register_an_invalid_handler_for_the_command(
         self,
@@ -133,7 +133,7 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(InvalidHandlerError):
-            bus.register_handler(FloodCommand, handler)  # type: ignore
+            bus.register_handler(FloodCommand, handler)  # type: ignore[misc]
 
     def test_register_handler_will_not_accept_multiple_handlers(self) -> None:
         command = ExplosionCommand()
@@ -142,4 +142,4 @@ class TestCommandBus:
         bus = CommandBus()
 
         with pytest.raises(TypeCheckError):
-            bus.register_handler(command, [handler1, handler2])  # type: ignore
+            bus.register_handler(command, [handler1, handler2])  # type: ignore[arg-type]

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -38,11 +38,6 @@ class UnionCommandHandler(CommandHandler[Union[ExplosionCommand, FloodCommand]])
         command.print_command_data()
 
 
-# class UnionCommandHandler(CommandHandler[Union[ExplosionCommand, FloodCommand]]):
-#     def handle(self, command: ExplosionCommand | FloodCommand) -> None:
-#         command.print_command_data()
-
-
 class ExplosionCommandHandler(CommandHandler[ExplosionCommand]):
     def handle(self, command: ExplosionCommand) -> None:
         command.print_command_data()

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typeguard import TypeCheckError
+
+from boss_bus.command_bus import (
+    Command,
+    CommandBus,
+    TooManyHandlersError,
+)
+from boss_bus.handler import MissingHandlerError
+from boss_bus.interface import IMessageHandler
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
+
+
+class ExplosionCommand(Command):
+    def print_command_data(self) -> None:
+        print("It went boom")
+
+
+class FloodCommand:
+    pass
+
+
+class AnyCommandHandler(IMessageHandler):
+    def handle(self, command: Command) -> None:  # noqa: ARG002
+        print("Hi")
+
+
+class ExplosionCommandHandler(IMessageHandler):
+    def handle(self, command: ExplosionCommand) -> None:
+        command.print_command_data()
+
+
+class SecondExplosionCommandHandler(IMessageHandler):
+    def handle(self, command: ExplosionCommand) -> None:
+        command.print_command_data()
+        print("again")
+
+
+class TestCommandBus:
+    def test_execute_accepts_a_specific_command(self) -> None:
+        command = ExplosionCommand()
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.execute(command, handler)
+
+    # def test_execute_does_not_accept_a_non_specific_command(self) -> None:
+    #     command = ExplosionCommand()
+    #     handler = AnyCommandHandler()
+    #     bus = CommandBus()
+    #
+    #     with pytest.raises(Exception):
+    #         bus.execute(command, handler)
+
+    def test_execute_does_not_accept_an_invalid_command(self) -> None:
+        command = FloodCommand()
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        with pytest.raises(TypeCheckError):
+            bus.execute(command, handler)  # type: ignore
+
+    def test_execute_does_not_accept_multiple_handlers(self) -> None:
+        command = ExplosionCommand()
+        handler1 = ExplosionCommandHandler()
+        handler2 = SecondExplosionCommandHandler()
+        bus = CommandBus()
+
+        with pytest.raises(TooManyHandlersError):
+            bus.execute(command, [handler1, handler2])  # type: ignore
+
+    def test_execute_cannot_execute_a_command_with_no_handlers(
+        self,
+    ) -> None:
+        command = ExplosionCommand()
+        bus = CommandBus()
+
+        with pytest.raises(MissingHandlerError):
+            bus.execute(command)
+
+    def test_execute_finds_a_previously_registered_command(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        command = ExplosionCommand()
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.register_handler(ExplosionCommand, handler)
+
+        bus.execute(command)
+
+        captured = capsys.readouterr()
+        assert captured.out == "It went boom\n"
+
+    def test_execute_does_not_accept_a_handler_if_one_is_already_registered(
+        self,
+    ) -> None:
+        command = ExplosionCommand()
+        handler1 = ExplosionCommandHandler()
+        handler2 = SecondExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.register_handler(ExplosionCommand, handler1)
+
+        with pytest.raises(TooManyHandlersError):
+            bus.execute(command, handler2)
+
+    def test_register_handler_requires_handlers_to_be_provided(self) -> None:
+        bus = CommandBus()
+
+        with pytest.raises(TypeError):
+            bus.register_handler(ExplosionCommand)  # type: ignore
+
+    def test_register_handler_requires_command_type_to_be_a_type(self) -> None:
+        command = ExplosionCommand()
+        handler1 = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        with pytest.raises(TypeCheckError):
+            bus.register_handler(command, handler1)  # type: ignore
+
+    def test_register_handler_will_not_register_an_invalid_command_for_the_handler(
+        self,
+    ) -> None:
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        with pytest.raises(TypeCheckError):
+            bus.register_handler(FloodCommand, handler)  # type: ignore

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -144,6 +144,12 @@ class TestCommandBus:
         with pytest.raises(TypeCheckError):
             bus.register_handler(command, [handler1, handler2])  # type: ignore[arg-type]
 
+    def test_register_handler_will_not_register_an_uninstantiated_handler(self) -> None:
+        bus = CommandBus()
+
+        with pytest.raises(TypeCheckError):
+            bus.register_handler(ExplosionCommand, [ExplosionCommandHandler])  # type: ignore[arg-type]
+
     def test_remove_handler_removes_handler_for_a_given_command_and_deletes_key(
         self,
     ) -> None:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -69,7 +69,7 @@ class TestEventBus:
         bus = EventBus()
 
         with pytest.raises(TypeCheckError):
-            bus.dispatch(event, [handler])  # type: ignore
+            bus.dispatch(event, [handler])  # type: ignore[arg-type]
 
     def test_dispatch_will_not_throw_exception_if_dispatching_an_event_with_no_handlers(
         self,
@@ -125,14 +125,14 @@ class TestEventBus:
         bus = EventBus()
 
         with pytest.raises(TypeCheckError):
-            bus.add_handlers(event, [handler1])  # type: ignore
+            bus.add_handlers(event, [handler1])  # type: ignore[arg-type]
 
     def test_add_handlers_will_not_register_an_invalid_event_and_handler(self) -> None:
         handler = ExplosionEventHandler()
         bus = EventBus()
 
         with pytest.raises(TypeCheckError):
-            bus.add_handlers(FloodEvent, [handler])  # type: ignore
+            bus.add_handlers(FloodEvent, [handler])  # type: ignore[arg-type]
 
     def test_remove_handlers_can_remove_all_handlers(self) -> None:
         handler1 = ExplosionEventHandler()
@@ -176,7 +176,7 @@ class TestEventBus:
         bus.add_handlers(ExplosionEvent, [handler])
 
         with pytest.raises(TypeCheckError):
-            bus.remove_handlers(FloodEvent, [handler])  # type: ignore
+            bus.remove_handlers(FloodEvent, [handler])  # type: ignore[arg-type]
 
     def test_remove_handlers_throws_exception_if_handler_is_not_registered(
         self,

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -43,14 +43,19 @@ class SecondExplosionEventHandler(IMessageHandler):
 
 
 class TestEventBus:
-    def test_dispatch_accepts_a_non_specific_event(self) -> None:
+    def test_dispatch_accepts_a_non_specific_event(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
         event = ExplosionEvent()
         handler = AnyEventHandler()
         bus = EventBus()
 
         bus.dispatch(event, [handler])
 
-    def test_dispatch_accepts_multiple_handlers(
+        captured = capsys.readouterr()
+        assert captured.out == "Hi\n"
+
+    def test_dispatch_accepts_a_list_of_handlers(
         self, capsys: CaptureFixture[str]
     ) -> None:
         event = ExplosionEvent()
@@ -59,6 +64,19 @@ class TestEventBus:
         bus = EventBus()
 
         bus.dispatch(event, [handler1, handler2])
+
+        captured = capsys.readouterr()
+        assert captured.out == "It went boom\nIt went boom\nagain\n"
+
+    def test_dispatch_accepts_a_tuple_of_handlers(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        event = ExplosionEvent()
+        handler1 = ExplosionEventHandler()
+        handler2 = SecondExplosionEventHandler()
+        bus = EventBus()
+
+        bus.dispatch(event, (handler1, handler2))
 
         captured = capsys.readouterr()
         assert captured.out == "It went boom\nIt went boom\nagain\n"
@@ -109,7 +127,7 @@ class TestEventBus:
         bus.dispatch(event, [handler3])
 
         captured = capsys.readouterr()
-        assert captured.out == "Hi\nIt went boom\nIt went boom\nagain\n"
+        assert captured.out == "It went boom\nIt went boom\nagain\nHi\n"
 
     def test_add_handlers_requires_handlers_to_be_provided(self) -> None:
         bus = EventBus()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -9,8 +9,8 @@ from boss_bus.event_bus import (
     Event,
     EventBus,
     MissingEventError,
-    MissingHandlerError,
 )
+from boss_bus.handler import MissingHandlerError
 from boss_bus.interface import IMessageHandler
 
 if TYPE_CHECKING:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -30,7 +30,7 @@ class AnyEventHandler(IMessageHandler):
         print("Hi")
 
 
-class ExplosionEventHandler(IMessageHandler):
+class ExplosionEventHandler:
     def handle(self, event: ExplosionEvent) -> None:
         event.print_event_data()
 
@@ -150,6 +150,12 @@ class TestEventBus:
 
         with pytest.raises(TypeCheckError):
             bus.add_handlers(FloodEvent, [handler])  # type: ignore[arg-type]
+
+    def test_add_handers_will_not_register_an_uninstantiated_handler(self) -> None:
+        bus = EventBus()
+
+        with pytest.raises(TypeError):
+            bus.add_handlers(ExplosionEvent, [ExplosionEventHandler])  # type: ignore[list-item]
 
     def test_remove_handlers_can_remove_all_handlers(self) -> None:
         handler1 = ExplosionEventHandler()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -10,7 +10,7 @@ from boss_bus.event_bus import (
     EventBus,
 )
 from boss_bus.handler import MissingHandlerError
-from boss_bus.interface import IMessageHandler
+from boss_bus.interface import SupportsHandle
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -25,7 +25,7 @@ class FloodEvent:
     pass
 
 
-class AnyEventHandler(IMessageHandler):
+class AnyEventHandler(SupportsHandle):
     def handle(self, event: Event) -> None:  # noqa: ARG002
         print("Hi")
 
@@ -35,7 +35,7 @@ class ExplosionEventHandler:
         event.print_event_data()
 
 
-class SecondExplosionEventHandler(IMessageHandler):
+class SecondExplosionEventHandler(SupportsHandle):
     def handle(self, event: ExplosionEvent) -> None:
         event.print_event_data()
         print("again")

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -128,14 +128,6 @@ class TestEventBus:
         captured = capsys.readouterr()
         assert captured.out == "It went boom\nIt went boom\nagain\nHi\n"
 
-    def test_add_handlers_requires_handlers_to_be_provided(self) -> None:
-        bus = EventBus()
-
-        with pytest.raises(TypeError) as e:
-            bus.add_handlers(ExplosionEvent, [])
-
-        assert str(e.value) == "add_handlers() requires at least one handler"
-
     def test_add_handlers_requires_event_type_to_be_a_type(self) -> None:
         event = ExplosionEvent()
         handler1 = ExplosionEventHandler()
@@ -154,7 +146,7 @@ class TestEventBus:
     def test_add_handers_will_not_register_an_uninstantiated_handler(self) -> None:
         bus = EventBus()
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             bus.add_handlers(ExplosionEvent, [ExplosionEventHandler])  # type: ignore[list-item]
 
     def test_remove_handlers_can_remove_all_handlers(self) -> None:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -8,7 +8,6 @@ from typeguard import TypeCheckError
 from boss_bus.event_bus import (
     Event,
     EventBus,
-    MissingEventError,
 )
 from boss_bus.handler import MissingHandlerError
 from boss_bus.interface import IMessageHandler
@@ -160,7 +159,7 @@ class TestEventBus:
 
         bus.remove_handlers(ExplosionEvent)
 
-        assert ExplosionEvent not in bus._handlers  # noqa: SLF001
+        assert not bus._handlers.get(ExplosionEvent)  # noqa: SLF001
 
     def test_remove_handlers_can_remove_specific_handlers(self) -> None:
         handler1 = ExplosionEventHandler()
@@ -173,19 +172,6 @@ class TestEventBus:
 
         assert ExplosionEvent in bus._handlers  # noqa: SLF001
         assert len(bus._handlers[ExplosionEvent]) == 1  # noqa: SLF001
-
-    def test_remove_handlers_deletes_event_key_if_all_handlers_are_removed_specifically(
-        self,
-    ) -> None:
-        handler1 = ExplosionEventHandler()
-        handler2 = SecondExplosionEventHandler()
-        bus = EventBus()
-
-        bus.add_handlers(ExplosionEvent, [handler1, handler2])
-
-        bus.remove_handlers(ExplosionEvent, [handler1, handler2])
-
-        assert ExplosionEvent not in bus._handlers  # noqa: SLF001
 
     def test_remove_handlers_will_not_accept_an_invalid_event_and_handler(self) -> None:
         handler = ExplosionEventHandler()
@@ -208,9 +194,9 @@ class TestEventBus:
         with pytest.raises(MissingHandlerError):
             bus.remove_handlers(ExplosionEvent, [handler2])
 
-    def test_remove_handlers_throws_exception_if_event_is_not_registered(self) -> None:
-        handler = ExplosionEventHandler()
+    def test_remove_handlers_does_not_throw_exception_if_event_is_not_registered(
+        self,
+    ) -> None:
         bus = EventBus()
 
-        with pytest.raises(MissingEventError):
-            bus.remove_handlers(ExplosionEvent, [handler])
+        bus.remove_handlers(ExplosionEvent)

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from boss_bus.interface import IMessageHandler
+from boss_bus.interface import SupportsHandle
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -24,17 +24,17 @@ class FloodMessage:
         print("It got wet")
 
 
-class AnyMessageHandler(IMessageHandler):
+class AnyMessageHandler(SupportsHandle):
     def handle(self, message: Any) -> None:  # noqa: ARG002
         print("Hi")
 
 
-class ExplosionMessageHandler(IMessageHandler):
+class ExplosionMessageHandler(SupportsHandle):
     def handle(self, message: ExplosionMessage) -> None:
         message.print_message_data()
 
 
-class SecondExplosionMessageHandler(IMessageHandler):
+class SecondExplosionMessageHandler(SupportsHandle):
     def handle(self, message: ExplosionMessage) -> None:
         pass
 


### PR DESCRIPTION
This proposes a new type of Message Bus that is used for 'executing' commands. Command Handlers are typed to a specific command (or a Union of commands if you really wanted multiple). Most importantly, the Command Bus will only register, or execute, a single handler for each command.

As part of this work, I've back-ported `inspect.get_annotations` from Python 3.10 to work in earlier versions. This has doesn't play well with type-checkers, particularly as I've had to put some import statements in try/catch blocks to selectively import based on Python version. Therefore, there are a lot of comment-ignored checks in the `_utils.typing` module. In addition, I've had some general issues with Typeguard. It doesn't seem to like the use of `annotations` from `future` in older Python versions. It also doesn't provide great error logs for debugging. I will continue to use it for now.