### PR TITLE
Create main library entry-point // MessageBus class

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ please [file an issue] along with a detailed description.
 Created by [@jimbroze].
 This project was generated from [@cjolowicz]'s [Hypermodern Python Cookiecutter] template.
 
+[@jimbroze]: https://github.com/jimbroze
 [@cjolowicz]: https://github.com/cjolowicz
 [pypi]: https://pypi.org/
 [hypermodern python cookiecutter]: https://github.com/cjolowicz/cookiecutter-hypermodern-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boss-bus"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Type-driven Message Bus for Python 3.8+"
 authors = ["Jim Dickinson <james.n.dickinson@gmail.com>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ select = [
     "UP",
     "W",
 ]
-ignore = ["E501"]
+ignore = ["E501", "UP006", "UP007"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S", "D100", "D101", "D102", "D103", "D104", "D205", "D212"]

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -45,7 +45,7 @@ class InvalidHandlerError(Exception):
 
 
 def _validate_handler(
-    command_type: Type[Command], handler: CommandHandler[Any]  # noqa UP006
+    command_type: Type[Command], handler: CommandHandler[Any]
 ) -> None:
     if not type_matches(get_annotations(handler.handle)["command"], command_type):
         raise InvalidHandlerError(
@@ -74,7 +74,7 @@ class CommandBus:
     @typechecked
     def register_handler(
         self,
-        command_type: Type[SpecificCommand],  # noqa: UP006
+        command_type: Type[SpecificCommand],
         handler: CommandHandler[SpecificCommand],
     ) -> None:
         """Register a single handler that will execute a type of Command."""
@@ -85,7 +85,7 @@ class CommandBus:
     @typechecked
     def remove_handler(
         self,
-        command_type: Type[SpecificCommand],  # noqa: UP006
+        command_type: Type[SpecificCommand],
     ) -> None:
         """Remove a previously registered handler."""
         if command_type not in self._handlers:

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -57,12 +57,12 @@ class CommandBus:
     """Executes commands using their associated handler.
 
     Example:
-        >>> from tests.examples import TestCommand, TestCommandHandler
+        >>> from tests.examples import ExampleCommand, ExampleCommandHandler
         >>> bus = CommandBus()
-        >>> test_handler = TestCommandHandler()
-        >>> test_command = TestCommand("Testing...")
+        >>> test_handler = ExampleCommandHandler()
+        >>> test_command = ExampleCommand("Testing...")
         >>>
-        >>> bus.register_handler(TestCommand, test_handler)
+        >>> bus.register_handler(ExampleCommand, test_handler)
         >>> bus.execute(test_command)
         Testing...
     """
@@ -104,10 +104,10 @@ class CommandBus:
         """Calls the handle method on a command's handler.
 
         Example:
-            >>> from tests.examples import TestCommand, TestCommandHandler
+            >>> from tests.examples import ExampleCommand, ExampleCommandHandler
             >>> bus = CommandBus()
-            >>> test_handler = TestCommandHandler()
-            >>> test_command = TestCommand("Testing...")
+            >>> test_handler = ExampleCommandHandler()
+            >>> test_command = ExampleCommand("Testing...")
             >>>
             >>> bus.execute(test_command, test_handler)
             Testing...

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -55,7 +55,7 @@ class EventBus:
     @typechecked
     def add_handlers(
         self,
-        event_type: Type[Event],  # noqa: UP006
+        event_type: Type[Event],
         handlers: Sequence[SupportsHandle],
     ) -> None:
         """Register handlers that will dispatch a type of Event."""
@@ -66,7 +66,7 @@ class EventBus:
     @typechecked
     def remove_handlers(
         self,
-        event_type: Type[Event],  # noqa: UP006
+        event_type: Type[Event],
         handlers: Sequence[SupportsHandle] | None = None,
     ) -> None:
         """Remove previously registered handlers."""

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -38,12 +38,12 @@ class EventBus:
     """Dispatches events to their associated handlers.
 
     Example:
-        >>> from tests.examples import TestEvent, TestEventHandler
+        >>> from tests.examples import ExampleEvent, ExampleEventHandler
         >>> bus = EventBus()
-        >>> test_handler = TestEventHandler()
-        >>> test_event = TestEvent("Testing...")
+        >>> test_handler = ExampleEventHandler()
+        >>> test_event = ExampleEvent("Testing...")
         >>>
-        >>> bus.add_handlers(TestEvent, [test_handler])
+        >>> bus.add_handlers(ExampleEvent, [test_handler])
         >>> bus.dispatch(test_event)
         Testing...
     """
@@ -96,10 +96,10 @@ class EventBus:
         Previously registered handlers dispatch first.
 
         Example:
-            >>> from tests.examples import TestEvent, TestEventHandler
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler
             >>> bus = EventBus()
-            >>> test_handler = TestEventHandler()
-            >>> test_event = TestEvent("Testing...")
+            >>> test_handler = ExampleEventHandler()
+            >>> test_event = ExampleEvent("Testing...")
             >>>
             >>> bus.dispatch(test_event, [test_handler])
             Testing...

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -50,6 +50,18 @@ class MessageBus:
             return self._register_command(message_type, handlers)
         raise TypeError("register() arg 1 must be an Event or a Command")
 
+    def deregister(
+        self,
+        message_type: Type[Event] | Type[SpecificCommand],
+        handlers: Sequence[SupportsHandle] | None = None,
+    ) -> None:
+        """Remove registered handlers for an event or command."""
+        if issubclass(message_type, Event):
+            return self._deregister_event(message_type, handlers)
+        if issubclass(message_type, Command):
+            return self._deregister_command(message_type)
+        raise TypeError("deregister() arg 1 must be an Event or a Command class")
+
     def execute(
         self,
         command: SpecificCommand,
@@ -99,3 +111,15 @@ class MessageBus:
     ) -> None:
         """Register a handler that will dispatch a type of Command."""
         self.command_bus.register_handler(message_type, handler)
+
+    def _deregister_event(
+        self,
+        message_type: Type[Event],
+        handlers: Any,
+    ) -> None:
+        """Remove handlers that are registered to dispatch an Event."""
+        self.event_bus.remove_handlers(message_type, handlers)
+
+    def _deregister_command(self, message_type: Type[SpecificCommand]) -> None:
+        """Remove a handler that is registered to execute a Command."""
+        self.command_bus.remove_handler(message_type)

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -1,0 +1,38 @@
+"""The main entrypoint to the Boss-Bus package.
+
+Classes:
+
+    MessageBus
+"""
+from __future__ import annotations
+
+from typeguard import typechecked
+
+from boss_bus.command_bus import CommandBus, CommandHandler, SpecificCommand
+
+
+class MessageBus:
+    """Forwards events and commands to their associated buses."""
+
+    def __init__(self) -> None:
+        """Creates a Message Bus."""
+        self.command_bus = CommandBus()
+
+    @typechecked
+    def execute(
+        self,
+        command: SpecificCommand,
+        handler: CommandHandler[SpecificCommand] | None = None,
+    ) -> None:
+        """Forwards a command to a CommandBus for execution.
+
+        Example:
+            >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+            >>> bus = MessageBus()
+            >>> test_handler = ExampleCommandHandler()
+            >>> test_command = ExampleCommand("Testing...")
+            >>>
+            >>> bus.execute(test_command, test_handler)
+            Testing...
+        """
+        self.command_bus.execute(command, handler)

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,8 +6,6 @@ Classes:
 """
 from __future__ import annotations
 
-from typeguard import typechecked
-
 from boss_bus.command_bus import CommandBus, CommandHandler, SpecificCommand
 
 
@@ -28,7 +26,6 @@ class MessageBus:
         """Creates a Message Bus."""
         self.command_bus = command_bus if command_bus is not None else CommandBus()
 
-    @typechecked
     def execute(
         self,
         command: SpecificCommand,

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -12,11 +12,21 @@ from boss_bus.command_bus import CommandBus, CommandHandler, SpecificCommand
 
 
 class MessageBus:
-    """Forwards events and commands to their associated buses."""
+    """Forwards events and commands to their associated buses.
 
-    def __init__(self) -> None:
+    Example:
+        >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+        >>> bus = MessageBus()
+        >>> test_handler = ExampleCommandHandler()
+        >>> test_command = ExampleCommand("Testing...")
+        >>>
+        >>> bus.execute(test_command, test_handler)
+        Testing...
+    """
+
+    def __init__(self, command_bus: CommandBus | None = None) -> None:
         """Creates a Message Bus."""
-        self.command_bus = CommandBus()
+        self.command_bus = command_bus if command_bus is not None else CommandBus()
 
     @typechecked
     def execute(

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,7 +6,13 @@ Classes:
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Sequence
+
 from boss_bus.command_bus import CommandBus, CommandHandler, SpecificCommand
+from boss_bus.event_bus import Event, EventBus
+
+if TYPE_CHECKING:
+    from boss_bus.interface import SupportsHandle
 
 
 class MessageBus:
@@ -22,9 +28,12 @@ class MessageBus:
         Testing...
     """
 
-    def __init__(self, command_bus: CommandBus | None = None) -> None:
+    def __init__(
+        self, command_bus: CommandBus | None = None, event_bus: EventBus | None = None
+    ) -> None:
         """Creates a Message Bus."""
         self.command_bus = command_bus if command_bus is not None else CommandBus()
+        self.event_bus = event_bus if event_bus is not None else EventBus()
 
     def execute(
         self,
@@ -43,3 +52,22 @@ class MessageBus:
             Testing...
         """
         self.command_bus.execute(command, handler)
+
+    def dispatch(
+        self, event: Event, handlers: Sequence[SupportsHandle] | None = None
+    ) -> None:
+        """Dispatch events to their handlers.
+
+        Handlers can be dispatched directly or pre-registered with 'add_handlers'.
+        Previously registered handlers dispatch first.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler
+            >>> bus = MessageBus()
+            >>> test_handler = ExampleEventHandler()
+            >>> test_event = ExampleEvent("Testing...")
+            >>>
+            >>> bus.dispatch(test_event, [test_handler])
+            Testing...
+        """
+        self.event_bus.dispatch(event, handlers)

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,10 +6,9 @@ Classes:
 """
 from __future__ import annotations
 
-from typing import Any, Sequence, Type
+from typing import Sequence, Type
 
 from boss_bus.command_bus import (
-    Command,
     CommandBus,
     CommandHandler,
     SpecificCommand,
@@ -37,30 +36,6 @@ class MessageBus:
         """Creates a Message Bus."""
         self.command_bus = command_bus if command_bus is not None else CommandBus()
         self.event_bus = event_bus if event_bus is not None else EventBus()
-
-    def register(
-        self,
-        message_type: Type[Event] | Type[SpecificCommand],
-        handlers: Sequence[SupportsHandle] | CommandHandler[SpecificCommand],
-    ) -> None:
-        """Register handlers that will dispatch an event or command."""
-        if issubclass(message_type, Event):
-            return self._register_event(message_type, handlers)
-        if issubclass(message_type, Command):
-            return self._register_command(message_type, handlers)
-        raise TypeError("register() arg 1 must be an Event or a Command")
-
-    def deregister(
-        self,
-        message_type: Type[Event] | Type[SpecificCommand],
-        handlers: Sequence[SupportsHandle] | None = None,
-    ) -> None:
-        """Remove registered handlers for an event or command."""
-        if issubclass(message_type, Event):
-            return self._deregister_event(message_type, handlers)
-        if issubclass(message_type, Command):
-            return self._deregister_command(message_type)
-        raise TypeError("deregister() arg 1 must be an Event or a Command class")
 
     def execute(
         self,
@@ -96,30 +71,30 @@ class MessageBus:
         """
         self.event_bus.dispatch(event, handlers)
 
-    def _register_event(
+    def register_event(
         self,
         message_type: Type[Event],
-        handlers: Any,
+        handlers: Sequence[SupportsHandle],
     ) -> None:
         """Register handlers that will dispatch a type of Event."""
         self.event_bus.add_handlers(message_type, handlers)
 
-    def _register_command(
+    def register_command(
         self,
         message_type: Type[SpecificCommand],
-        handler: Any,
+        handler: CommandHandler[SpecificCommand],
     ) -> None:
         """Register a handler that will dispatch a type of Command."""
         self.command_bus.register_handler(message_type, handler)
 
-    def _deregister_event(
+    def deregister_event(
         self,
         message_type: Type[Event],
-        handlers: Any,
+        handlers: Sequence[SupportsHandle],
     ) -> None:
         """Remove handlers that are registered to dispatch an Event."""
         self.event_bus.remove_handlers(message_type, handlers)
 
-    def _deregister_command(self, message_type: Type[SpecificCommand]) -> None:
+    def deregister_command(self, message_type: Type[SpecificCommand]) -> None:
         """Remove a handler that is registered to execute a Command."""
         self.command_bus.remove_handler(message_type)

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -3,7 +3,7 @@ from boss_bus.event_bus import Event
 from boss_bus.interface import SupportsHandle
 
 
-class TestEvent(Event):
+class ExampleEvent(Event):
     """A type of event purely for use in tests."""
 
     def __init__(self, event_data: str):
@@ -14,15 +14,15 @@ class TestEvent(Event):
         print(self.event_data)
 
 
-class TestEventHandler(SupportsHandle):
+class ExampleEventHandler(SupportsHandle):
     """An event handler purely for use in tests."""
 
-    def handle(self, event: TestEvent) -> None:
+    def handle(self, event: ExampleEvent) -> None:
         """Handle a test event."""
         event.print_event_data()
 
 
-class TestCommand(Command):
+class ExampleCommand(Command):
     """A type of command purely for use in tests."""
 
     def __init__(self, command_data: str):
@@ -33,9 +33,9 @@ class TestCommand(Command):
         print(self.command_data)
 
 
-class TestCommandHandler(CommandHandler[TestCommand]):
+class ExampleCommandHandler(CommandHandler[ExampleCommand]):
     """A command handler purely for use in tests."""
 
-    def handle(self, command: TestCommand) -> None:
+    def handle(self, command: ExampleCommand) -> None:
         """Handle a test command."""
         command.print_command_data()

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -59,7 +59,7 @@ class TestMessageBus:
 
         assert ExampleCommand in bus.command_bus._handlers  # noqa: SLF001
 
-    def test_event_register_with_the_event_bus(self) -> None:
+    def test_event_registers_with_the_event_bus(self) -> None:
         handler = ExampleEventHandler()
         bus = MessageBus()
 
@@ -73,3 +73,30 @@ class TestMessageBus:
 
         with pytest.raises(TypeError):
             bus.register(ExampleEventHandler, [handler])  # type: ignore[type-var]
+
+    def test_command_deregisters_with_the_command_bus(self) -> None:
+        command_bus = CommandBus()
+        bus = MessageBus(command_bus=command_bus)
+        handler = ExampleCommandHandler()
+
+        bus.register(ExampleCommand, handler)
+        bus.deregister(ExampleCommand)
+
+        assert ExampleCommand not in command_bus._handlers  # noqa: SLF001
+
+    def test_event_deregisters_with_the_event_bus(self) -> None:
+        handler = ExampleEventHandler()
+        event_bus = EventBus()
+        bus = MessageBus(event_bus=event_bus)
+
+        bus.register(ExampleEvent, [handler])
+        bus.deregister(ExampleEvent, [handler])
+
+        assert handler not in event_bus._handlers.get(ExampleEvent, [])  # noqa: SLF001
+
+    def test_only_events_and_commands_can_be_deregistered(self) -> None:
+        handler = ExampleEventHandler()
+        bus = MessageBus()
+
+        with pytest.raises(TypeError):
+            bus.deregister(ExampleEventHandler, [handler])  # type: ignore[type-var]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,0 +1,11 @@
+from boss_bus.message_bus import MessageBus
+from tests.examples import ExampleCommand, ExampleCommandHandler
+
+
+class TestMessageBus:
+    def test_execute_executes_a_command(self) -> None:
+        command = ExampleCommand("Test the bus")
+        handler = ExampleCommandHandler()
+        bus = MessageBus()
+
+        bus.execute(command, handler)

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -2,6 +2,7 @@ import pytest
 from typeguard import TypeCheckError
 
 from boss_bus.command_bus import CommandBus
+from boss_bus.event_bus import EventBus
 from boss_bus.message_bus import MessageBus
 from tests.examples import (
     ExampleCommand,
@@ -12,11 +13,13 @@ from tests.examples import (
 
 
 class TestMessageBus:
-    def test_can_created_with_custom_command_bus(self) -> None:
+    def test_can_created_with_custom_command_and_event_bus(self) -> None:
         command_bus = CommandBus()
-        bus = MessageBus(command_bus=command_bus)
+        event_bus = EventBus()
+        bus = MessageBus(command_bus=command_bus, event_bus=event_bus)
 
-        bus.command_bus = command_bus
+        assert bus.command_bus == command_bus
+        assert bus.event_bus == event_bus
 
     def test_execute_executes_a_command(self) -> None:
         command = ExampleCommand("Test the bus")
@@ -29,5 +32,21 @@ class TestMessageBus:
         event = ExampleEvent("Test the bus")
         handler = ExampleEventHandler()
         bus = MessageBus()
+
         with pytest.raises(TypeCheckError):
             bus.execute(event, handler)  # type: ignore[type-var, arg-type]
+
+    def test_an_event_can_be_dispatched(self) -> None:
+        event = ExampleEvent("Test the bus")
+        handler = ExampleEventHandler()
+        bus = MessageBus()
+
+        bus.dispatch(event, [handler])
+
+    def test_a_command_cannot_be_dispatched(self) -> None:
+        command = ExampleCommand("Test the bus")
+        handler = ExampleCommandHandler()
+        bus = MessageBus()
+
+        with pytest.raises(TypeCheckError):
+            bus.dispatch(command, handler)  # type: ignore[arg-type]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,6 +1,14 @@
+import pytest
+from typeguard import TypeCheckError
+
 from boss_bus.command_bus import CommandBus
 from boss_bus.message_bus import MessageBus
-from tests.examples import ExampleCommand, ExampleCommandHandler
+from tests.examples import (
+    ExampleCommand,
+    ExampleCommandHandler,
+    ExampleEvent,
+    ExampleEventHandler,
+)
 
 
 class TestMessageBus:
@@ -16,3 +24,10 @@ class TestMessageBus:
         bus = MessageBus()
 
         bus.execute(command, handler)
+
+    def test_an_event_cannot_be_executed(self) -> None:
+        event = ExampleEvent("Test the bus")
+        handler = ExampleEventHandler()
+        bus = MessageBus()
+        with pytest.raises(TypeCheckError):
+            bus.execute(event, handler)  # type: ignore[type-var, arg-type]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -55,7 +55,7 @@ class TestMessageBus:
         handler = ExampleCommandHandler()
         bus = MessageBus()
 
-        bus.register(ExampleCommand, handler)
+        bus.register_command(ExampleCommand, handler)
 
         assert ExampleCommand in bus.command_bus._handlers  # noqa: SLF001
 
@@ -63,24 +63,17 @@ class TestMessageBus:
         handler = ExampleEventHandler()
         bus = MessageBus()
 
-        bus.register(ExampleEvent, [handler])
+        bus.register_event(ExampleEvent, [handler])
 
         assert ExampleEvent in bus.event_bus._handlers  # noqa: SLF001
-
-    def test_only_events_and_commands_can_be_registered(self) -> None:
-        handler = ExampleEventHandler()
-        bus = MessageBus()
-
-        with pytest.raises(TypeError):
-            bus.register(ExampleEventHandler, [handler])  # type: ignore[type-var]
 
     def test_command_deregisters_with_the_command_bus(self) -> None:
         command_bus = CommandBus()
         bus = MessageBus(command_bus=command_bus)
         handler = ExampleCommandHandler()
 
-        bus.register(ExampleCommand, handler)
-        bus.deregister(ExampleCommand)
+        bus.register_command(ExampleCommand, handler)
+        bus.deregister_command(ExampleCommand)
 
         assert ExampleCommand not in command_bus._handlers  # noqa: SLF001
 
@@ -89,14 +82,7 @@ class TestMessageBus:
         event_bus = EventBus()
         bus = MessageBus(event_bus=event_bus)
 
-        bus.register(ExampleEvent, [handler])
-        bus.deregister(ExampleEvent, [handler])
+        bus.register_event(ExampleEvent, [handler])
+        bus.deregister_event(ExampleEvent, [handler])
 
         assert handler not in event_bus._handlers.get(ExampleEvent, [])  # noqa: SLF001
-
-    def test_only_events_and_commands_can_be_deregistered(self) -> None:
-        handler = ExampleEventHandler()
-        bus = MessageBus()
-
-        with pytest.raises(TypeError):
-            bus.deregister(ExampleEventHandler, [handler])  # type: ignore[type-var]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -50,3 +50,26 @@ class TestMessageBus:
 
         with pytest.raises(TypeCheckError):
             bus.dispatch(command, handler)  # type: ignore[arg-type]
+
+    def test_command_registers_with_the_command_bus(self) -> None:
+        handler = ExampleCommandHandler()
+        bus = MessageBus()
+
+        bus.register(ExampleCommand, handler)
+
+        assert ExampleCommand in bus.command_bus._handlers  # noqa: SLF001
+
+    def test_event_register_with_the_event_bus(self) -> None:
+        handler = ExampleEventHandler()
+        bus = MessageBus()
+
+        bus.register(ExampleEvent, [handler])
+
+        assert ExampleEvent in bus.event_bus._handlers  # noqa: SLF001
+
+    def test_only_events_and_commands_can_be_registered(self) -> None:
+        handler = ExampleEventHandler()
+        bus = MessageBus()
+
+        with pytest.raises(TypeError):
+            bus.register(ExampleEventHandler, [handler])  # type: ignore[type-var]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,8 +1,15 @@
+from boss_bus.command_bus import CommandBus
 from boss_bus.message_bus import MessageBus
 from tests.examples import ExampleCommand, ExampleCommandHandler
 
 
 class TestMessageBus:
+    def test_can_created_with_custom_command_bus(self) -> None:
+        command_bus = CommandBus()
+        bus = MessageBus(command_bus=command_bus)
+
+        bus.command_bus = command_bus
+
     def test_execute_executes_a_command(self) -> None:
         command = ExampleCommand("Test the bus")
         handler = ExampleCommandHandler()


### PR DESCRIPTION
MessageBus is a form of facade/mediator which delegates functionality to the `EventBus` and `CommandBus` classes. It will allow instantiation of the bus classes with default parameters.

Initially, I looked at using shared methods for registering and de-registering commands and events but found that if provided extra complexity with no real benefit. Users could create simple helper methods to achieve the same functionality if they really wanted, such as looping through a list of both events and commands. Separating the methods simplifies type-hinting which will become even more important when these methods are modified to accept both classes and objects. Furthermore, they make the language and naming more explicit and relevant to the type of messages they deal with.

While creating shared methods (see https://github.com/jimbroze/boss-bus/commit/2684314c4323d83f002b1de70248c2ea6b7a2e90 and https://github.com/jimbroze/boss-bus/commit/fdfaa1be2bedfc9c0e2cfe7067441cd411ba40d0), I experimented with python's built in `inspect.singledispatch` and the [multimethod library](https://github.com/coady/multimethod). Unfortunately, I abandoned them both, in this scenario, for the following reasons:
- singledispatch: Does not allow dispatching using arguments that are classes, rather than instances/objects
- multimethod: This should have worked in theory, but I found a strange bug where the dispatch would randomly work in one test and then not work in a re-test of the same code. I can only assume this is down to the caching done internally for dispatching. It's also likely related to the use of complex typing (TypeVars and Generics)

I've been thinking about the use of runtime typechecking and whether it's necessary. It obviously creates additional code and reduced performance and I would generally advocate using it in application-based code. However, I didn't know where the drawbacks are worth it in a public library. If the code is type-hinted and the public API is clear then it could be argued that any further type-checking is the responsibility of users? IDE linting and static type-checking should show any issues. I will leave the existing runtime typechecking in and consider this throughout development.