### PR TITLE
Class loader

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-poetry run coverage run -m pytest --xdoctest "$@"
+poetry run coverage run -m pytest --xdoctest --typeguard-packages=boss_bus "$@"
 poetry run coverage report
 poetry run mypy src tests
 poetry run ruff .

--- a/noxfile.py
+++ b/noxfile.py
@@ -144,6 +144,7 @@ def mypy(session: Session) -> None:
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
     session.install("mypy", "pytest", "pytest-testdox")
+    session.install("lagom")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
@@ -154,6 +155,7 @@ def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
     session.install("coverage[toml]", "pytest", "pytest-testdox", "pygments")
+    session.install("lagom")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
@@ -180,6 +182,7 @@ def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
     session.install("pytest", "pytest-testdox", "typeguard", "pygments")
+    session.install("lagom")
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -113,101 +113,101 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.3.1"
+version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.3.1.tar.gz", hash = "sha256:d9137a876020661972ca6eec0766d81aef8a5627df628b664b234b73396e727e"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8aee051c89e13565c6bd366813c386939f8e928af93c29fda4af86d25b73d8f8"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:352a88c3df0d1fa886562384b86f9a9e27563d4704ee0e9d56ec6fcd270ea690"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:223b4d54561c01048f657fa6ce41461d5ad8ff128b9678cfe8b2ecd951e3f8a2"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f861d94c2a450b974b86093c6c027888627b8082f1299dfd5a4bae8e2292821"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1171ef1fc5ab4693c5d151ae0fdad7f7349920eabbaca6271f95969fa0756c2d"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28f512b9a33235545fbbdac6a330a510b63be278a50071a336afc1b78781b147"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0e842112fe3f1a4ffcf64b06dc4c61a88441c2f02f373367f7b4c1aa9be2ad5"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f9bc2ce123637a60ebe819f9fccc614da1bcc05798bbbaf2dd4ec91f3e08846"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f194cce575e59ffe442c10a360182a986535fd90b57f7debfaa5c845c409ecc3"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9a74041ba0bfa9bc9b9bb2cd3238a6ab3b7618e759b41bd15b5f6ad958d17605"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b578cbe580e3b41ad17b1c428f382c814b32a6ce90f2d8e39e2e635d49e498d1"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:6db3cfb9b4fcecb4390db154e75b49578c87a3b9979b40cdf90d7e4b945656e1"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:debb633f3f7856f95ad957d9b9c781f8e2c6303ef21724ec94bea2ce2fcbd056"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-win32.whl", hash = "sha256:87071618d3d8ec8b186d53cb6e66955ef2a0e4fa63ccd3709c0c90ac5a43520f"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:e372d7dfd154009142631de2d316adad3cc1c36c32a38b16a4751ba78da2a397"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae4070f741f8d809075ef697877fd350ecf0b7c5837ed68738607ee0a2c572cf"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:58e875eb7016fd014c0eea46c6fa92b87b62c0cb31b9feae25cbbe62c919f54d"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbd95e300367aa0827496fe75a1766d198d34385a58f97683fe6e07f89ca3e3c"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de0b4caa1c8a21394e8ce971997614a17648f94e1cd0640fbd6b4d14cab13a72"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:985c7965f62f6f32bf432e2681173db41336a9c2611693247069288bcb0c7f8b"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a15c1fe6d26e83fd2e5972425a772cca158eae58b05d4a25a4e474c221053e2d"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae55d592b02c4349525b6ed8f74c692509e5adffa842e582c0f861751701a673"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be4d9c2770044a59715eb57c1144dedea7c5d5ae80c68fb9959515037cde2008"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:851cf693fb3aaef71031237cd68699dded198657ec1e76a76eb8be58c03a5d1f"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:31bbaba7218904d2eabecf4feec0d07469284e952a27400f23b6628439439fa7"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:871d045d6ccc181fd863a3cd66ee8e395523ebfbc57f85f91f035f50cee8e3d4"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:501adc5eb6cd5f40a6f77fbd90e5ab915c8fd6e8c614af2db5561e16c600d6f3"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f5fb672c396d826ca16a022ac04c9dce74e00a1c344f6ad1a0fdc1ba1f332213"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-win32.whl", hash = "sha256:bb06098d019766ca16fc915ecaa455c1f1cd594204e7f840cd6258237b5079a8"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:8af5a8917b8af42295e86b64903156b4f110a30dca5f3b5aedea123fbd638bff"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:7ae8e5142dcc7a49168f4055255dbcced01dc1714a90a21f87448dc8d90617d1"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5b70bab78accbc672f50e878a5b73ca692f45f5b5e25c8066d748c09405e6a55"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5ceca5876032362ae73b83347be8b5dbd2d1faf3358deb38c9c88776779b2e2f"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d95638ff3613849f473afc33f65c401a89f3b9528d0d213c7037c398a51296"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9edbe6a5bf8b56a4a84533ba2b2f489d0046e755c29616ef8830f9e7d9cf5728"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6a02a3c7950cafaadcd46a226ad9e12fc9744652cc69f9e5534f98b47f3bbcf"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10b8dd31e10f32410751b3430996f9807fc4d1587ca69772e2aa940a82ab571a"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edc0202099ea1d82844316604e17d2b175044f9bcb6b398aab781eba957224bd"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b891a2f68e09c5ef989007fac11476ed33c5c9994449a4e2c3386529d703dc8b"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:71ef3b9be10070360f289aea4838c784f8b851be3ba58cf796262b57775c2f14"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:55602981b2dbf8184c098bc10287e8c245e351cd4fdcad050bd7199d5a8bf514"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:46fb9970aa5eeca547d7aa0de5d4b124a288b42eaefac677bde805013c95725c"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:520b7a142d2524f999447b3a0cf95115df81c4f33003c51a6ab637cbda9d0bf4"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-win32.whl", hash = "sha256:8ec8ef42c6cd5856a7613dcd1eaf21e5573b2185263d87d27c8edcae33b62a61"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:baec8148d6b8bd5cee1ae138ba658c71f5b03e0d69d5907703e3e1df96db5e41"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:63a6f59e2d01310f754c270e4a257426fe5a591dc487f1983b3bbe793cf6bac6"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d6bfc32a68bc0933819cfdfe45f9abc3cae3877e1d90aac7259d57e6e0f85b1"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4f3100d86dcd03c03f7e9c3fdb23d92e32abbca07e7c13ebd7ddfbcb06f5991f"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39b70a6f88eebe239fa775190796d55a33cfb6d36b9ffdd37843f7c4c1b5dc67"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e12f8ee80aa35e746230a2af83e81bd6b52daa92a8afaef4fea4a2ce9b9f4fa"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b6cefa579e1237ce198619b76eaa148b71894fb0d6bcf9024460f9bf30fd228"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:61f1e3fb621f5420523abb71f5771a204b33c21d31e7d9d86881b2cffe92c47c"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4f6e2a839f83a6a76854d12dbebde50e4b1afa63e27761549d006fa53e9aa80e"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:1ec937546cad86d0dce5396748bf392bb7b62a9eeb8c66efac60e947697f0e58"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:82ca51ff0fc5b641a2d4e1cc8c5ff108699b7a56d7f3ad6f6da9dbb6f0145b48"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:633968254f8d421e70f91c6ebe71ed0ab140220469cf87a9857e21c16687c034"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-win32.whl", hash = "sha256:c0c72d34e7de5604df0fde3644cc079feee5e55464967d10b24b1de268deceb9"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:63accd11149c0f9a99e3bc095bbdb5a464862d77a7e309ad5938fbc8721235ae"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5a3580a4fdc4ac05f9e53c57f965e3594b2f99796231380adb2baaab96e22761"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2465aa50c9299d615d757c1c888bc6fef384b7c4aec81c05a0172b4400f98557"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cb7cd68814308aade9d0c93c5bd2ade9f9441666f8ba5aa9c2d4b389cb5e2a45"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91e43805ccafa0a91831f9cd5443aa34528c0c3f2cc48c4cb3d9a7721053874b"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:854cc74367180beb327ab9d00f964f6d91da06450b0855cbbb09187bcdb02de5"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c15070ebf11b8b7fd1bfff7217e9324963c82dbdf6182ff7050519e350e7ad9f"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c4c99f98fc3a1835af8179dcc9013f93594d0670e2fa80c83aa36346ee763d2"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3fb765362688821404ad6cf86772fc54993ec11577cd5a92ac44b4c2ba52155b"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dced27917823df984fe0c80a5c4ad75cf58df0fbfae890bc08004cd3888922a2"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a66bcdf19c1a523e41b8e9d53d0cedbfbac2e93c649a2e9502cb26c014d0980c"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ecd26be9f112c4f96718290c10f4caea6cc798459a3a76636b817a0ed7874e42"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3f70fd716855cd3b855316b226a1ac8bdb3caf4f7ea96edcccc6f484217c9597"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:17a866d61259c7de1bdadef418a37755050ddb4b922df8b356503234fff7932c"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-win32.whl", hash = "sha256:548eefad783ed787b38cb6f9a574bd8664468cc76d1538215d510a3cd41406cb"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:45f053a0ece92c734d874861ffe6e3cc92150e32136dd59ab1fb070575189c97"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bc791ec3fd0c4309a753f95bb6c749ef0d8ea3aea91f07ee1cf06b7b02118f2f"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8c61fb505c7dad1d251c284e712d4e0372cef3b067f7ddf82a7fa82e1e9a93"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2c092be3885a1b7899cd85ce24acedc1034199d6fca1483fa2c3a35c86e43041"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2000c54c395d9e5e44c99dc7c20a64dc371f777faf8bae4919ad3e99ce5253e"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4cb50a0335382aac15c31b61d8531bc9bb657cfd848b1d7158009472189f3d62"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c30187840d36d0ba2893bc3271a36a517a717f9fd383a98e2697ee890a37c273"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe81b35c33772e56f4b6cf62cf4aedc1762ef7162a31e6ac7fe5e40d0149eb67"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0bf89afcbcf4d1bb2652f6580e5e55a840fdf87384f6063c4a4f0c95e378656"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:06cf46bdff72f58645434d467bf5228080801298fbba19fe268a01b4534467f5"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3c66df3f41abee950d6638adc7eac4730a306b022570f71dd0bd6ba53503ab57"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:cd805513198304026bd379d1d516afbf6c3c13f4382134a2c526b8b854da1c2e"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:9505dc359edb6a330efcd2be825fdb73ee3e628d9010597aa1aee5aa63442e97"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:31445f38053476a0c4e6d12b047b08ced81e2c7c712e5a1ad97bc913256f91b2"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-win32.whl", hash = "sha256:bd28b31730f0e982ace8663d108e01199098432a30a4c410d06fe08fdb9e93f4"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:555fe186da0068d3354cdf4bbcbc609b0ecae4d04c921cc13e209eece7720727"},
-    {file = "charset_normalizer-3.3.1-py3-none-any.whl", hash = "sha256:800561453acdecedaac137bf09cd719c7a440b6800ec182f077bb8e7025fb708"},
+    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
+    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
 
 [[package]]
@@ -499,6 +499,42 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "lagom"
+version = "2.5.0"
+description = "Lagom is a dependency injection container designed to give you 'just enough' help with building your dependencies."
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "lagom-2.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b608bfa5855d6f0f898f3d2801417229557730620d9bc7cc035dc508eb272c27"},
+    {file = "lagom-2.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f09f5a7c1b328ebafc534bb3910793652a24a36eadee872bbaea42904bcbc5af"},
+    {file = "lagom-2.5.0-cp310-cp310-win32.whl", hash = "sha256:725e9f9313bb72200539e7314973f1b64cb95f595c315ad3c7146f5aaae934dd"},
+    {file = "lagom-2.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:2d7c50622610c70a69daf83f99c40678e3505dbe8b99774ea03fc3ccb8d437fb"},
+    {file = "lagom-2.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f49e9d1ad4da5ba96b4602403bf5ab80ce4a3b907143e7edf75ffa7d3fd1b7a"},
+    {file = "lagom-2.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dbc24c08be222e204c513a194e3dac3e209601065bee96d00ec33eee16378403"},
+    {file = "lagom-2.5.0-cp311-cp311-win32.whl", hash = "sha256:646916f3afe508685fd1ef9659264c44f12622e6739ab0e35020f0f400235b1b"},
+    {file = "lagom-2.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:7e495d4263e36acb4dc9a08fa812194807afe12a6fd31ae90b7344301de63f04"},
+    {file = "lagom-2.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:db341d662afb3a925d2172fb54e3751faf4cad9f6afd3c2cf5fc4cfda3fbae91"},
+    {file = "lagom-2.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c93688caca0f7be456441860f797995f9c74d7761a96082ce01fa92191947b85"},
+    {file = "lagom-2.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c2894a65dc4c2a2a83615d37df3285852e409819f90ed3fda3a33b6a271bc8b2"},
+    {file = "lagom-2.5.0-cp37-cp37m-win32.whl", hash = "sha256:452bf42acff6d9de25ebf7325a1d25ca991d40f0ebfdda2be4058a7e3f525656"},
+    {file = "lagom-2.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bb4d5de02f59fcc8b16412443e4bc9c8a694fbffd200dbc6ead6c965cc7f18ff"},
+    {file = "lagom-2.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:eee5764b241c778b36a5e22a21cb03837b001fdd6daa9568ab327b1d8be94c6d"},
+    {file = "lagom-2.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5dc703d0ba72d04887767ca7d0350c2217bb9efb96f2b4d979aa5ee13089f68"},
+    {file = "lagom-2.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4556fabb05bf1408383fca759dd612679b8b49287a4b5ef319c4c7cdb7ce7b92"},
+    {file = "lagom-2.5.0-cp38-cp38-win32.whl", hash = "sha256:ee5a431c42f4a54f3f7a27440fc07511ff3e975b8d0063ec32f2e97743235a37"},
+    {file = "lagom-2.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:31ee67b2ad70dd24cf9539cd4d889abf8006d7314632eccda186a5bbc5a69cf5"},
+    {file = "lagom-2.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7a9b2da5737e0df4684a785507a23cb5cd8f818da57494da11793698e8b3a1ed"},
+    {file = "lagom-2.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:469787a78c3e24d9ca042080dbb0e0808618f18946628c71f7f38ad616eb8764"},
+    {file = "lagom-2.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3b915af0ab1e58cd38ca8c7841ec2fae35cd5ffef157d11df908e400e7f934c9"},
+    {file = "lagom-2.5.0-cp39-cp39-win32.whl", hash = "sha256:5594a6a158dc2cdda88e85ba40dab109914422e0d3c08753c7a8fd0d994fd201"},
+    {file = "lagom-2.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:cc426370a8f663ca15105c60ef3d5b2bc3f974b18d138755eedbf2a786011909"},
+    {file = "lagom-2.5.0-py3-none-any.whl", hash = "sha256:64d25db5df407b77b76b169ead465c678927a1a47d79ad4a0424059b343312cb"},
+]
+
+[package.extras]
+env = ["pydantic (>=1.0.0,<3.0.0)"]
 
 [[package]]
 name = "livereload"
@@ -1010,13 +1046,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.3"
+version = "0.18.5"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
-python-versions = ">=3"
+python-versions = ">=3.7"
 files = [
-    {file = "ruamel.yaml-0.18.3-py3-none-any.whl", hash = "sha256:b5d119e1f9678cf90b58f64bbd2a4e78af76860ae39fab3e73323e622b462df9"},
-    {file = "ruamel.yaml-0.18.3.tar.gz", hash = "sha256:36dbbe90390d977f957436570d2bd540bfd600e6ec5a1ea42bcdb9fc7963d802"},
+    {file = "ruamel.yaml-0.18.5-py3-none-any.whl", hash = "sha256:a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada"},
+    {file = "ruamel.yaml-0.18.5.tar.gz", hash = "sha256:61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e"},
 ]
 
 [package.dependencies]
@@ -1087,28 +1123,28 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.1.3"
-description = "An extremely fast Python linter, written in Rust."
+version = "0.1.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.1.3-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:b46d43d51f7061652eeadb426a9e3caa1e0002470229ab2fc19de8a7b0766901"},
-    {file = "ruff-0.1.3-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b8afeb9abd26b4029c72adc9921b8363374f4e7edb78385ffaa80278313a15f9"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca3cf365bf32e9ba7e6db3f48a4d3e2c446cd19ebee04f05338bc3910114528b"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4874c165f96c14a00590dcc727a04dca0cfd110334c24b039458c06cf78a672e"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eec2dd31eed114e48ea42dbffc443e9b7221976554a504767ceaee3dd38edeb8"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dc3ec4edb3b73f21b4aa51337e16674c752f1d76a4a543af56d7d04e97769613"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e3de9ed2e39160800281848ff4670e1698037ca039bda7b9274f849258d26ce"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c595193881922cc0556a90f3af99b1c5681f0c552e7a2a189956141d8666fe8"},
-    {file = "ruff-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f75e670d529aa2288cd00fc0e9b9287603d95e1536d7a7e0cafe00f75e0dd9d"},
-    {file = "ruff-0.1.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76dd49f6cd945d82d9d4a9a6622c54a994689d8d7b22fa1322983389b4892e20"},
-    {file = "ruff-0.1.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:918b454bc4f8874a616f0d725590277c42949431ceb303950e87fef7a7d94cb3"},
-    {file = "ruff-0.1.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d8859605e729cd5e53aa38275568dbbdb4fe882d2ea2714c5453b678dca83784"},
-    {file = "ruff-0.1.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0b6c55f5ef8d9dd05b230bb6ab80bc4381ecb60ae56db0330f660ea240cb0d4a"},
-    {file = "ruff-0.1.3-py3-none-win32.whl", hash = "sha256:3e7afcbdcfbe3399c34e0f6370c30f6e529193c731b885316c5a09c9e4317eef"},
-    {file = "ruff-0.1.3-py3-none-win_amd64.whl", hash = "sha256:7a18df6638cec4a5bd75350639b2bb2a2366e01222825562c7346674bdceb7ea"},
-    {file = "ruff-0.1.3-py3-none-win_arm64.whl", hash = "sha256:12fd53696c83a194a2db7f9a46337ce06445fb9aa7d25ea6f293cf75b21aca9f"},
-    {file = "ruff-0.1.3.tar.gz", hash = "sha256:3ba6145369a151401d5db79f0a47d50e470384d0d89d0d6f7fab0b589ad07c34"},
+    {file = "ruff-0.1.4-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:864958706b669cce31d629902175138ad8a069d99ca53514611521f532d91495"},
+    {file = "ruff-0.1.4-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9fdd61883bb34317c788af87f4cd75dfee3a73f5ded714b77ba928e418d6e39e"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4eaca8c9cc39aa7f0f0d7b8fe24ecb51232d1bb620fc4441a61161be4a17539"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a9a1301dc43cbf633fb603242bccd0aaa34834750a14a4c1817e2e5c8d60de17"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78e8db8ab6f100f02e28b3d713270c857d370b8d61871d5c7d1702ae411df683"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:80fea754eaae06335784b8ea053d6eb8e9aac75359ebddd6fee0858e87c8d510"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6bc02a480d4bfffd163a723698da15d1a9aec2fced4c06f2a753f87f4ce6969c"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9862811b403063765b03e716dac0fda8fdbe78b675cd947ed5873506448acea4"},
+    {file = "ruff-0.1.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58826efb8b3efbb59bb306f4b19640b7e366967a31c049d49311d9eb3a4c60cb"},
+    {file = "ruff-0.1.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fdfd453fc91d9d86d6aaa33b1bafa69d114cf7421057868f0b79104079d3e66e"},
+    {file = "ruff-0.1.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e8791482d508bd0b36c76481ad3117987301b86072158bdb69d796503e1c84a8"},
+    {file = "ruff-0.1.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01206e361021426e3c1b7fba06ddcb20dbc5037d64f6841e5f2b21084dc51800"},
+    {file = "ruff-0.1.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:645591a613a42cb7e5c2b667cbefd3877b21e0252b59272ba7212c3d35a5819f"},
+    {file = "ruff-0.1.4-py3-none-win32.whl", hash = "sha256:99908ca2b3b85bffe7e1414275d004917d1e0dfc99d497ccd2ecd19ad115fd0d"},
+    {file = "ruff-0.1.4-py3-none-win_amd64.whl", hash = "sha256:1dfd6bf8f6ad0a4ac99333f437e0ec168989adc5d837ecd38ddb2cc4a2e3db8a"},
+    {file = "ruff-0.1.4-py3-none-win_arm64.whl", hash = "sha256:d98ae9ebf56444e18a3e3652b3383204748f73e247dea6caaf8b52d37e6b32da"},
+    {file = "ruff-0.1.4.tar.gz", hash = "sha256:21520ecca4cc555162068d87c747b8f95e1e95f8ecfcbbe59e8dd00710586315"},
 ]
 
 [[package]]
@@ -1499,7 +1535,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+lagom = ["lagom"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "9ed4fe3c89ba51878b327f82135224374b0f08a7a5668f54057ab07ead9b4caf"
+content-hash = "a8216d8e94708376a0b6e7cd7f8638fe0f04d40d90aa5393521037fbf0a44801"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ select = [
 ignore = ["E501", "UP006", "UP007"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S", "D100", "D101", "D102", "D103", "D104", "D205", "D212"]
+"tests/*" = ["S", "D100", "D101", "D102", "D103", "D104", "D107", "D205", "D212"]
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ python = "^3.8.1"
 click = ">=8.0.1"
 typeguard = ">=2.13.3"
 
+# Optional
+lagom = { version = "^2.4", optional = true }
+
+[tool.poetry.extras]
+lagom = ["lagom"]
+
 [tool.poetry.group.dev.dependencies]
 Pygments = ">=2.10.0"
 black = ">=23.10.1"

--- a/src/boss_bus/loader.py
+++ b/src/boss_bus/loader.py
@@ -7,7 +7,11 @@ Class loading classes should implement the Interface (ClassLoader)
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Type, TypeVar, overload
+from typing import Type, TypeVar, get_type_hints, overload
+
+from ._utils.typing import get_annotations
+
+RETURN_ANNOTATION = "return"
 
 obj = TypeVar("obj")
 
@@ -48,5 +52,10 @@ class ClassInstantiator(ClassLoader):
         if not isinstance(cls, type):
             return cls
 
-        instance: obj = cls()
+        deps = get_type_hints(cls.__init__)  # type: ignore[misc]
+        print(get_annotations(cls.__init__))  # type: ignore[misc]
+        deps.pop(RETURN_ANNOTATION, None)
+        dep_instances = {dep_name: dep() for dep_name, dep in deps.items()}
+
+        instance: obj = cls(**dep_instances)
         return instance

--- a/src/boss_bus/loader.py
+++ b/src/boss_bus/loader.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Type, TypeVar, get_type_hints, overload
 
-from ._utils.typing import get_annotations
-
 RETURN_ANNOTATION = "return"
 
 obj = TypeVar("obj", bound=object)
@@ -58,7 +56,6 @@ class ClassInstantiator(ClassLoader):
     def instantiate(self, cls: type[obj]) -> obj:
         """Instantiates a class and any simple dependencies it has."""
         dependencies = get_type_hints(cls.__init__)
-        print(get_annotations(cls.__init__))
         dependencies.pop(RETURN_ANNOTATION, None)
 
         dependency_instances = {

--- a/src/boss_bus/loader.py
+++ b/src/boss_bus/loader.py
@@ -1,0 +1,52 @@
+"""Classes that load dependencies and use them to instantiate classes.
+
+Class loading classes should implement the Interface (ClassLoader)
+"""
+
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Type, TypeVar, overload
+
+obj = TypeVar("obj")
+
+
+class ClassLoader(ABC):
+    """An Interface that allows loading dependencies and instantiating classes."""
+
+    @overload
+    def load(self, cls: Type[obj]) -> obj:
+        pass
+
+    @overload
+    def load(self, cls: obj) -> obj:
+        pass
+
+    @abstractmethod
+    def load(self, cls: Type[obj] | obj) -> obj:
+        """Loads a class' dependencies and instantiates it."""
+
+
+class ClassInstantiator(ClassLoader):
+    """Instantiates a class with no complex dependencies.
+
+    Dependencies are instantiated recursively.
+    Throws an exception if a class, or it's dependencies, cannot be instantiated
+    """
+
+    @overload
+    def load(self, cls: Type[obj]) -> obj:
+        pass
+
+    @overload
+    def load(self, cls: obj) -> obj:
+        pass
+
+    def load(self, cls: Type[obj] | obj) -> obj:
+        """Instantiates a class and any simple dependencies it has."""
+        if not isinstance(cls, type):
+            return cls
+
+        instance: obj = cls()
+        return instance

--- a/src/boss_bus/loader/__init__.py
+++ b/src/boss_bus/loader/__init__.py
@@ -1,0 +1,26 @@
+"""Classes that load dependencies and use them to instantiate classes.
+
+Class loading classes should implement the Interface (ClassLoader)
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Type, TypeVar, overload
+
+obj = TypeVar("obj", bound=object)
+
+
+class ClassLoader(ABC):
+    """An Interface that allows loading dependencies and instantiating classes."""
+
+    @overload
+    def load(self, cls: Type[obj]) -> obj:
+        pass
+
+    @overload
+    def load(self, cls: obj) -> obj:
+        pass
+
+    @abstractmethod
+    def load(self, cls: Type[obj] | obj) -> obj:
+        """Instantiates a class or returns an already instantiated instance."""

--- a/src/boss_bus/loader/instantiator.py
+++ b/src/boss_bus/loader/instantiator.py
@@ -1,33 +1,13 @@
-"""Classes that load dependencies and use them to instantiate classes.
-
-Class loading classes should implement the Interface (ClassLoader)
-"""
+"""Default ClassLoader that instantiates simple classes."""
 
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Type, TypeVar, get_type_hints, overload
+from typing import Type, get_type_hints, overload
+
+from boss_bus.loader import ClassLoader, obj
 
 RETURN_ANNOTATION = "return"
-
-obj = TypeVar("obj", bound=object)
-
-
-class ClassLoader(ABC):
-    """An Interface that allows loading dependencies and instantiating classes."""
-
-    @overload
-    def load(self, cls: Type[obj]) -> obj:
-        pass
-
-    @overload
-    def load(self, cls: obj) -> obj:
-        pass
-
-    @abstractmethod
-    def load(self, cls: Type[obj] | obj) -> obj:
-        """Instantiates a class or returns an already instantiated instance."""
 
 
 class ClassInstantiator(ClassLoader):

--- a/src/boss_bus/loader/lagom_loader.py
+++ b/src/boss_bus/loader/lagom_loader.py
@@ -1,0 +1,36 @@
+"""An optional module that allows using the DI container Lagom, as a class Loader."""
+
+from __future__ import annotations
+
+from typing import Type, overload
+
+from lagom import Container
+
+from boss_bus.loader import ClassLoader, obj
+
+
+class LagomLoader(ClassLoader):
+    """Uses a Lagom DI container as a class Loader."""
+
+    def __init__(
+        self,
+        container: Container | None = None,
+    ):
+        """Creates an adapter to connect Lagom."""
+        self.container = container if container is not None else Container()
+
+    @overload
+    def load(self, cls: Type[obj]) -> obj:
+        pass
+
+    @overload
+    def load(self, cls: obj) -> obj:
+        pass
+
+    def load(self, cls: type[obj] | obj) -> obj:
+        """Instantiates a class or returns an already instantiated instance."""
+        if not isinstance(cls, type):
+            return cls
+
+        # noinspection PyTypeChecker
+        return self.container[cls]

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -39,7 +39,7 @@ class MessageBus:
         class_loader: ClassLoader | None = None,
         command_bus: CommandBus | None = None,
         event_bus: EventBus | None = None,
-    ) -> None:
+    ):
         """Creates a Message Bus."""
         self.loader = class_loader if class_loader is not None else ClassInstantiator()
         self.command_bus = command_bus if command_bus is not None else CommandBus()

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence, Type
 
+from typeguard import typeguard_ignore
+
 from boss_bus.command_bus import (
     CommandBus,
     CommandHandler,
@@ -88,6 +90,7 @@ class MessageBus:
         loaded_handlers = [self.loader.load(handler) for handler in handlers]
         self.event_bus.add_handlers(message_type, loaded_handlers)
 
+    @typeguard_ignore
     def register_command(
         self,
         message_type: Type[SpecificCommand],

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,7 +6,7 @@ Classes:
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Type
+from typing import TYPE_CHECKING, Sequence, Type, Union
 
 from typeguard import typeguard_ignore
 
@@ -94,8 +94,9 @@ class MessageBus:
     def register_command(
         self,
         message_type: Type[SpecificCommand],
-        handler: Type[CommandHandler[SpecificCommand]]
-        | CommandHandler[SpecificCommand],
+        handler: Union[
+            Type[CommandHandler[SpecificCommand]], CommandHandler[SpecificCommand]
+        ],
     ) -> None:
         """Register a handler that will dispatch a type of Command."""
         loaded_handler = self.loader.load(handler)

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -77,6 +77,7 @@ class MessageBus:
         handlers: Sequence[SupportsHandle],
     ) -> None:
         """Register handlers that will dispatch a type of Event."""
+        # loaded_handlers = [self.loader.load(handler) for handler in handlers]
         self.event_bus.add_handlers(message_type, handlers)
 
     def register_command(

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,7 +6,7 @@ Classes:
 """
 from __future__ import annotations
 
-from typing import Sequence, Type
+from typing import TYPE_CHECKING, Sequence, Type
 
 from boss_bus.command_bus import (
     CommandBus,
@@ -15,7 +15,10 @@ from boss_bus.command_bus import (
 )
 from boss_bus.event_bus import Event, EventBus
 from boss_bus.interface import SupportsHandle  # noqa: TCH001
-from boss_bus.loader import ClassInstantiator, ClassLoader
+from boss_bus.loader.instantiator import ClassInstantiator
+
+if TYPE_CHECKING:
+    from boss_bus.loader import ClassLoader
 
 
 class MessageBus:

--- a/tests/loader/examples.py
+++ b/tests/loader/examples.py
@@ -1,0 +1,24 @@
+class NoDeps:
+    def __init__(self) -> None:
+        self.output = "No dependencies loaded"
+
+
+class SimpleDeps:
+    def __init__(self, dep_one: NoDeps, dep_two: NoDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = "One dependency loaded"
+
+
+class LayeredDeps:
+    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = "Layered dependencies loaded"
+
+
+class CustomDeps:
+    def __init__(self, dep_one: str, dep_two: SimpleDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = self.dep_one

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -1,4 +1,4 @@
-from boss_bus.loader import ClassInstantiator
+from boss_bus.loader.instantiator import ClassInstantiator
 
 
 class NoDeps:

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -7,14 +7,14 @@ class NoDeps:
 
 
 class SimpleDeps:
-    def __init__(self, dep_one: NoDeps, dep_two: NoDeps) -> None:
+    def __init__(self, dep_one: NoDeps, dep_two: NoDeps):
         self.dep_one = dep_one
         self.dep_two = dep_two
         self.output = "One dependency loaded"
 
 
 class LayeredDeps:
-    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps) -> None:
+    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps):
         self.dep_one = dep_one
         self.dep_two = dep_two
         self.output = "Layered dependencies loaded"

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -1,23 +1,5 @@
 from boss_bus.loader.instantiator import ClassInstantiator
-
-
-class NoDeps:
-    def __init__(self) -> None:
-        self.output = "No dependencies loaded"
-
-
-class SimpleDeps:
-    def __init__(self, dep_one: NoDeps, dep_two: NoDeps):
-        self.dep_one = dep_one
-        self.dep_two = dep_two
-        self.output = "One dependency loaded"
-
-
-class LayeredDeps:
-    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps):
-        self.dep_one = dep_one
-        self.dep_two = dep_two
-        self.output = "Layered dependencies loaded"
+from tests.loader.examples import LayeredDeps, NoDeps, SimpleDeps
 
 
 class TestClassInstantiator:

--- a/tests/loader/test_lagom_loader.py
+++ b/tests/loader/test_lagom_loader.py
@@ -1,0 +1,77 @@
+from lagom import Container
+
+from boss_bus.loader.lagom_loader import LagomLoader
+
+
+class NoDeps:
+    def __init__(self) -> None:
+        self.output = "No dependencies loaded"
+
+
+class SimpleDeps:
+    def __init__(self, dep_one: NoDeps, dep_two: NoDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = "One dependency loaded"
+
+
+class LayeredDeps:
+    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = "Layered dependencies loaded"
+
+
+class CustomDeps:
+    def __init__(self, dep_one: str, dep_two: SimpleDeps):
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = self.dep_one
+
+
+class TestClassInstantiator:
+    def test_lagom_load_returns_instance_if_provided(self) -> None:
+        loader = LagomLoader()
+        instance = NoDeps()
+
+        loaded_class = loader.load(instance)
+        assert isinstance(loaded_class, NoDeps)
+        assert loaded_class.output == "No dependencies loaded"
+
+    def test_lagom_load_instantiates_class_with_no_dependencies(self) -> None:
+        loader = LagomLoader()
+
+        loaded_class = loader.load(NoDeps)
+        assert isinstance(loaded_class, NoDeps)
+        assert loaded_class.output == "No dependencies loaded"
+
+    def test_lagom_load_instantiates_class_with_multiple_layers_of_simple_dependencies(
+        self,
+    ) -> None:
+        loader = LagomLoader()
+
+        loaded_class = loader.load(LayeredDeps)
+        assert isinstance(loaded_class, LayeredDeps)
+        assert loaded_class.output == "Layered dependencies loaded"
+        assert loaded_class.dep_one.output == "One dependency loaded"
+
+    def test_lagom_load_accepts_a_custom_container(
+        self,
+    ) -> None:
+        loader = LagomLoader(Container())
+
+        loaded_class = loader.load(LayeredDeps)
+        assert isinstance(loaded_class, LayeredDeps)
+
+    def test_lagom_load_resolves_complex_types(
+        self,
+    ) -> None:
+        container = Container()
+        container[CustomDeps] = lambda simple_dep: CustomDeps(
+            "Class created", simple_dep
+        )
+        loader = LagomLoader(container)
+
+        loaded_class = loader.load(CustomDeps)
+        assert isinstance(loaded_class, CustomDeps)
+        assert loaded_class.output == "Class created"

--- a/tests/loader/test_lagom_loader.py
+++ b/tests/loader/test_lagom_loader.py
@@ -1,32 +1,7 @@
 from lagom import Container
 
 from boss_bus.loader.lagom_loader import LagomLoader
-
-
-class NoDeps:
-    def __init__(self) -> None:
-        self.output = "No dependencies loaded"
-
-
-class SimpleDeps:
-    def __init__(self, dep_one: NoDeps, dep_two: NoDeps):
-        self.dep_one = dep_one
-        self.dep_two = dep_two
-        self.output = "One dependency loaded"
-
-
-class LayeredDeps:
-    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps):
-        self.dep_one = dep_one
-        self.dep_two = dep_two
-        self.output = "Layered dependencies loaded"
-
-
-class CustomDeps:
-    def __init__(self, dep_one: str, dep_two: SimpleDeps):
-        self.dep_one = dep_one
-        self.dep_two = dep_two
-        self.output = self.dep_one
+from tests.loader.examples import CustomDeps, LayeredDeps, NoDeps
 
 
 class TestClassInstantiator:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,7 +2,14 @@ from boss_bus.loader import ClassInstantiator
 
 
 class NoDeps:
-    output = "No dependencies loaded"
+    def __init__(self) -> None:
+        self.output = "No dependencies loaded"
+
+
+class SimpleDeps:
+    def __init__(self, dep: NoDeps) -> None:
+        self.dep = dep
+        self.output = "One dependency loaded"
 
 
 class TestClassInstantiator:
@@ -11,10 +18,21 @@ class TestClassInstantiator:
         instance = NoDeps()
 
         loaded_class = loader.load(instance)
+        assert isinstance(loaded_class, NoDeps)
         assert loaded_class.output == "No dependencies loaded"
 
     def test_load_instantiates_class_with_no_dependencies(self) -> None:
         loader = ClassInstantiator()
 
         loaded_class = loader.load(NoDeps)
+        assert isinstance(loaded_class, NoDeps)
         assert loaded_class.output == "No dependencies loaded"
+
+    def test_load_instantiates_class_with_one_layer_of_simple_dependencies(
+        self,
+    ) -> None:
+        loader = ClassInstantiator()
+
+        loaded_class = loader.load(SimpleDeps)
+        assert isinstance(loaded_class, SimpleDeps)
+        assert loaded_class.output == "One dependency loaded"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,20 @@
+from boss_bus.loader import ClassInstantiator
+
+
+class NoDeps:
+    output = "No dependencies loaded"
+
+
+class TestClassInstantiator:
+    def test_load_returns_instance_if_provided(self) -> None:
+        loader = ClassInstantiator()
+        instance = NoDeps()
+
+        loaded_class = loader.load(instance)
+        assert loaded_class.output == "No dependencies loaded"
+
+    def test_load_instantiates_class_with_no_dependencies(self) -> None:
+        loader = ClassInstantiator()
+
+        loaded_class = loader.load(NoDeps)
+        assert loaded_class.output == "No dependencies loaded"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -7,9 +7,17 @@ class NoDeps:
 
 
 class SimpleDeps:
-    def __init__(self, dep: NoDeps) -> None:
-        self.dep = dep
+    def __init__(self, dep_one: NoDeps, dep_two: NoDeps) -> None:
+        self.dep_one = dep_one
+        self.dep_two = dep_two
         self.output = "One dependency loaded"
+
+
+class LayeredDeps:
+    def __init__(self, dep_one: SimpleDeps, dep_two: NoDeps) -> None:
+        self.dep_one = dep_one
+        self.dep_two = dep_two
+        self.output = "Layered dependencies loaded"
 
 
 class TestClassInstantiator:
@@ -36,3 +44,13 @@ class TestClassInstantiator:
         loaded_class = loader.load(SimpleDeps)
         assert isinstance(loaded_class, SimpleDeps)
         assert loaded_class.output == "One dependency loaded"
+
+    def test_load_instantiates_class_with_multiple_layers_of_simple_dependencies(
+        self,
+    ) -> None:
+        loader = ClassInstantiator()
+
+        loaded_class = loader.load(LayeredDeps)
+        assert isinstance(loaded_class, LayeredDeps)
+        assert loaded_class.output == "Layered dependencies loaded"
+        assert loaded_class.dep_one.output == "One dependency loaded"

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.capture import CaptureFixture
 from typeguard import TypeCheckError
 
 from boss_bus.command_bus import CommandBus
@@ -86,3 +87,27 @@ class TestMessageBus:
         bus.deregister_event(ExampleEvent, [handler])
 
         assert handler not in event_bus._handlers.get(ExampleEvent, [])  # noqa: SLF001
+
+    def test_default_loader_instantiates_event_classes(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        bus = MessageBus()
+        event = ExampleEvent("Testing...")
+
+        bus.register_event(ExampleEvent, [ExampleEventHandler])
+        bus.dispatch(event)
+
+        captured = capsys.readouterr()
+        assert captured.out == "Testing...\n"
+
+    def test_default_loader_instantiates_command_classes(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        bus = MessageBus()
+        command = ExampleCommand("Testing...")
+
+        bus.register_command(ExampleCommand, ExampleCommandHandler)
+        bus.execute(command)
+
+        captured = capsys.readouterr()
+        assert captured.out == "Testing...\n"


### PR DESCRIPTION
A new interface, `ClassLoader`, allows uninstantiated handler classes to be registered with the MessageBus. This interface and its implementations are responsible for instantiating the handler class and loading its dependencies. This is currently only done in the 'register' methods as the classes are loaded before being stored in the bus.

The default implementation `ClassInstantiator` is capable of recursively instantiating dependencies as long as none of them have other dependencies that cannot themselves be instantiated.

A DI Container implementation has also been added that uses an optional Container library, [Lagom](https://github.com/meadsteve/lagom). This is a really powerful feature that allows the bus to auto-inject all kinds of complex dependencies into handlers.