### PR TITLE
Return values from commands

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,5 @@
-poetry run coverage run -m pytest --xdoctest --typeguard-packages=boss_bus "$@"
+poetry run coverage run -m pytest --xdoctest "$@"
 poetry run coverage report
 poetry run mypy src tests
+poetry run pytest --typeguard-packages=boss_bus -o addopts=
 poetry run ruff .

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,7 @@
-poetry run coverage run -m pytest --xdoctest "$@"
-poetry run coverage report
-poetry run mypy src tests
-poetry run pytest --typeguard-packages=boss_bus -o addopts=
-poetry run ruff .
+poetry run ruff . --fix
+poetry run coverage run -m pytest --xdoctest "$@" && \
+    poetry run coverage report && \
+    poetry run mypy src tests && \
+    poetry run pytest --typeguard-packages=boss_bus -o addopts= && \
+    poetry run ruff . && \
+    echo "--------------- ALL TESTS PASSED ---------------"

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -32,7 +32,7 @@ class CommandHandler(ABC, SupportsHandle, Generic[SpecificCommand]):
     """A form of message which only has one handler."""
 
     @abstractmethod
-    def handle(self, command: SpecificCommand) -> None:
+    def handle(self, command: SpecificCommand) -> Any:
         """Perform actions using a specific command."""
 
 
@@ -100,7 +100,7 @@ class CommandBus:
         self,
         command: SpecificCommand,
         handler: CommandHandler[SpecificCommand] | None = None,
-    ) -> None:
+    ) -> Any:
         """Calls the handle method on a command's handler.
 
         Example:
@@ -127,4 +127,4 @@ class CommandBus:
                 f"A handler has not been registered for the command '{type(command).__name__}'"
             )
 
-        matched_handler.handle(command)
+        return matched_handler.handle(command)

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -57,12 +57,12 @@ class CommandBus:
     """Executes commands using their associated handler.
 
     Example:
-        >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+        >>> from tests.examples import PrintCommand, PrintCommandHandler
         >>> bus = CommandBus()
-        >>> test_handler = ExampleCommandHandler()
-        >>> test_command = ExampleCommand("Testing...")
+        >>> test_handler = PrintCommandHandler()
+        >>> test_command = PrintCommand("Testing...")
         >>>
-        >>> bus.register_handler(ExampleCommand, test_handler)
+        >>> bus.register_handler(PrintCommand, test_handler)
         >>> bus.execute(test_command)
         Testing...
     """
@@ -104,10 +104,10 @@ class CommandBus:
         """Calls the handle method on a command's handler.
 
         Example:
-            >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
             >>> bus = CommandBus()
-            >>> test_handler = ExampleCommandHandler()
-            >>> test_command = ExampleCommand("Testing...")
+            >>> test_handler = PrintCommandHandler()
+            >>> test_command = PrintCommand("Testing...")
             >>>
             >>> bus.execute(test_command, test_handler)
             Testing...

--- a/src/boss_bus/loader/instantiator.py
+++ b/src/boss_bus/loader/instantiator.py
@@ -25,7 +25,7 @@ class ClassInstantiator(ClassLoader):
     def load(self, cls: obj) -> obj:
         pass
 
-    def load(self, cls: type[obj] | obj) -> obj:
+    def load(self, cls: Type[obj] | obj) -> obj:
         """Instantiates a class or returns an already instantiated instance."""
         if not isinstance(cls, type):
             return cls
@@ -33,7 +33,7 @@ class ClassInstantiator(ClassLoader):
         # noinspection PyTypeChecker
         return self.instantiate(cls)
 
-    def instantiate(self, cls: type[obj]) -> obj:
+    def instantiate(self, cls: Type[obj]) -> obj:
         """Instantiates a class and any simple dependencies it has."""
         dependencies = get_type_hints(cls.__init__)
         dependencies.pop(RETURN_ANNOTATION, None)

--- a/src/boss_bus/loader/lagom_loader.py
+++ b/src/boss_bus/loader/lagom_loader.py
@@ -27,7 +27,7 @@ class LagomLoader(ClassLoader):
     def load(self, cls: obj) -> obj:
         pass
 
-    def load(self, cls: type[obj] | obj) -> obj:
+    def load(self, cls: Type[obj] | obj) -> obj:
         """Instantiates a class or returns an already instantiated instance."""
         if not isinstance(cls, type):
             return cls

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -27,10 +27,10 @@ class MessageBus:
     """Forwards events and commands to their associated buses.
 
     Example:
-        >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+        >>> from tests.examples import PrintCommand, PrintCommandHandler
         >>> bus = MessageBus()
-        >>> test_handler = ExampleCommandHandler()
-        >>> test_command = ExampleCommand("Testing...")
+        >>> test_handler = PrintCommandHandler()
+        >>> test_command = PrintCommand("Testing...")
         >>>
         >>> bus.execute(test_command, test_handler)
         Testing...
@@ -55,10 +55,10 @@ class MessageBus:
         """Forwards a command to a CommandBus for execution.
 
         Example:
-            >>> from tests.examples import ExampleCommand, ExampleCommandHandler
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
             >>> bus = MessageBus()
-            >>> test_handler = ExampleCommandHandler()
-            >>> test_command = ExampleCommand("Testing...")
+            >>> test_handler = PrintCommandHandler()
+            >>> test_command = PrintCommand("Testing...")
             >>>
             >>> bus.execute(test_command, test_handler)
             Testing...

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -6,7 +6,7 @@ Classes:
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Sequence, Type, Union
 
 from typeguard import typeguard_ignore
 
@@ -51,7 +51,7 @@ class MessageBus:
         self,
         command: SpecificCommand,
         handler: CommandHandler[SpecificCommand] | None = None,
-    ) -> None:
+    ) -> Any:
         """Forwards a command to a CommandBus for execution.
 
         Example:
@@ -63,7 +63,7 @@ class MessageBus:
             >>> bus.execute(test_command, test_handler)
             Testing...
         """
-        self.command_bus.execute(command, handler)
+        return self.command_bus.execute(command, handler)
 
     def dispatch(
         self, event: Event, handlers: Sequence[SupportsHandle] | None = None

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -48,13 +48,10 @@ class ReturnCommand(Command):
         """Creates a command for tests."""
         self.command_data = command_data
 
-    def return_command_data(self) -> str:
-        return self.command_data
-
 
 class ReturnCommandHandler(CommandHandler[ReturnCommand]):
     """A command handler purely for use in tests."""
 
-    def handle(self, command: ReturnCommand) -> None:
+    def handle(self, command: ReturnCommand) -> str:
         """Handle a test command."""
-        command.return_command_data()
+        return command.command_data

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -22,8 +22,8 @@ class ExampleEventHandler(SupportsHandle):
         event.print_event_data()
 
 
-class ExampleCommand(Command):
-    """A type of command purely for use in tests."""
+class PrintCommand(Command):
+    """A command purely for use in tests."""
 
     def __init__(self, command_data: str):
         """Creates a command for tests."""
@@ -33,9 +33,28 @@ class ExampleCommand(Command):
         print(self.command_data)
 
 
-class ExampleCommandHandler(CommandHandler[ExampleCommand]):
+class PrintCommandHandler(CommandHandler[PrintCommand]):
     """A command handler purely for use in tests."""
 
-    def handle(self, command: ExampleCommand) -> None:
+    def handle(self, command: PrintCommand) -> None:
         """Handle a test command."""
         command.print_command_data()
+
+
+class ReturnCommand(Command):
+    """A command purely for use in tests."""
+
+    def __init__(self, command_data: str):
+        """Creates a command for tests."""
+        self.command_data = command_data
+
+    def return_command_data(self) -> str:
+        return self.command_data
+
+
+class ReturnCommandHandler(CommandHandler[ReturnCommand]):
+    """A command handler purely for use in tests."""
+
+    def handle(self, command: ReturnCommand) -> None:
+        """Handle a test command."""
+        command.return_command_data()

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -13,6 +13,10 @@ from boss_bus.command_bus import (
     TooManyHandlersError,
 )
 from boss_bus.handler import MissingHandlerError
+from tests.examples import (
+    ReturnCommand,
+    ReturnCommandHandler,
+)
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
@@ -129,6 +133,15 @@ class TestCommandBus:
 
         captured = capsys.readouterr()
         assert captured.out == "It got wet\n"
+
+    def test_execute_can_return_a_value(self) -> None:
+        command = ReturnCommand("Returned a value")
+        handler = ReturnCommandHandler()
+        bus = CommandBus()
+
+        result = bus.execute(command, handler)
+
+        assert result == "Returned a value"
 
     def test_register_handler_requires_handlers_to_be_provided(self) -> None:
         bus = CommandBus()

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -10,6 +10,8 @@ from tests.examples import (
     ExampleEventHandler,
     PrintCommand,
     PrintCommandHandler,
+    ReturnCommand,
+    ReturnCommandHandler,
 )
 
 
@@ -28,6 +30,15 @@ class TestMessageBus:
         bus = MessageBus()
 
         bus.execute(command, handler)
+
+    def test_execute_can_return_a_value(self) -> None:
+        command = ReturnCommand("Test the bus")
+        handler = ReturnCommandHandler()
+        bus = MessageBus()
+
+        result = bus.execute(command, handler)
+
+        assert result == "Test the bus"
 
     def test_an_event_cannot_be_executed(self) -> None:
         event = ExampleEvent("Test the bus")

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -6,10 +6,10 @@ from boss_bus.command_bus import CommandBus
 from boss_bus.event_bus import EventBus
 from boss_bus.message_bus import MessageBus
 from tests.examples import (
-    ExampleCommand,
-    ExampleCommandHandler,
     ExampleEvent,
     ExampleEventHandler,
+    PrintCommand,
+    PrintCommandHandler,
 )
 
 
@@ -23,8 +23,8 @@ class TestMessageBus:
         assert bus.event_bus == event_bus
 
     def test_execute_executes_a_command(self) -> None:
-        command = ExampleCommand("Test the bus")
-        handler = ExampleCommandHandler()
+        command = PrintCommand("Test the bus")
+        handler = PrintCommandHandler()
         bus = MessageBus()
 
         bus.execute(command, handler)
@@ -45,20 +45,20 @@ class TestMessageBus:
         bus.dispatch(event, [handler])
 
     def test_a_command_cannot_be_dispatched(self) -> None:
-        command = ExampleCommand("Test the bus")
-        handler = ExampleCommandHandler()
+        command = PrintCommand("Test the bus")
+        handler = PrintCommandHandler()
         bus = MessageBus()
 
         with pytest.raises(TypeCheckError):
             bus.dispatch(command, handler)  # type: ignore[arg-type]
 
     def test_command_registers_with_the_command_bus(self) -> None:
-        handler = ExampleCommandHandler()
+        handler = PrintCommandHandler()
         bus = MessageBus()
 
-        bus.register_command(ExampleCommand, handler)
+        bus.register_command(PrintCommand, handler)
 
-        assert ExampleCommand in bus.command_bus._handlers  # noqa: SLF001
+        assert PrintCommand in bus.command_bus._handlers  # noqa: SLF001
 
     def test_event_registers_with_the_event_bus(self) -> None:
         handler = ExampleEventHandler()
@@ -71,12 +71,12 @@ class TestMessageBus:
     def test_command_deregisters_with_the_command_bus(self) -> None:
         command_bus = CommandBus()
         bus = MessageBus(command_bus=command_bus)
-        handler = ExampleCommandHandler()
+        handler = PrintCommandHandler()
 
-        bus.register_command(ExampleCommand, handler)
-        bus.deregister_command(ExampleCommand)
+        bus.register_command(PrintCommand, handler)
+        bus.deregister_command(PrintCommand)
 
-        assert ExampleCommand not in command_bus._handlers  # noqa: SLF001
+        assert PrintCommand not in command_bus._handlers  # noqa: SLF001
 
     def test_event_deregisters_with_the_event_bus(self) -> None:
         handler = ExampleEventHandler()
@@ -104,9 +104,9 @@ class TestMessageBus:
         self, capsys: CaptureFixture[str]
     ) -> None:
         bus = MessageBus()
-        command = ExampleCommand("Testing...")
+        command = PrintCommand("Testing...")
 
-        bus.register_command(ExampleCommand, ExampleCommandHandler)
+        bus.register_command(PrintCommand, PrintCommandHandler)
         bus.execute(command)
 
         captured = capsys.readouterr()


### PR DESCRIPTION
Events operate under a publish/subscribe, observer style pattern where a single event can have multiple handlers. This means that it doesn't make sense for event handlers to return a value or result. As long as an event is successfully dispatched with no errors, the dispatcher does not care what happens downstream.

A command, however, has a single handler and performs a specific action or set of actions. It therefore makes sense that a command handler can return a value after executing a command. For example, a common use case for command handlers is performing an action based on data received in an API request. The handler can then return the results of the action for an API controller to use in a response.