### PR TITLE
Add methods to check registered handlers

### DIFF
--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -83,10 +83,7 @@ class CommandBus:
         self._handlers[command_type] = handler
 
     @typechecked
-    def remove_handler(
-        self,
-        command_type: Type[SpecificCommand],
-    ) -> None:
+    def remove_handler(self, command_type: Type[SpecificCommand]) -> None:
         """Remove a previously registered handler."""
         if command_type not in self._handlers:
             raise MissingHandlerError(
@@ -95,10 +92,7 @@ class CommandBus:
 
         del self._handlers[command_type]
 
-    def is_registered(
-        self,
-        command_type: Type[SpecificCommand],
-    ) -> bool:
+    def is_registered(self, command_type: Type[SpecificCommand]) -> bool:
         """Checks if a command is registered with the bus."""
         if command_type in self._handlers:
             return True

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -95,6 +95,16 @@ class CommandBus:
 
         del self._handlers[command_type]
 
+    def is_registered(
+        self,
+        command_type: Type[SpecificCommand],
+    ) -> bool:
+        """Checks if a command is registered with the bus."""
+        if command_type in self._handlers:
+            return True
+
+        return False
+
     @typechecked
     def execute(
         self,

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -77,14 +77,33 @@ class CommandBus:
         command_type: Type[SpecificCommand],
         handler: CommandHandler[SpecificCommand],
     ) -> None:
-        """Register a single handler that will execute a type of Command."""
+        """Register a single handler that will execute a type of Command.
+
+        Example:
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
+            >>> bus = CommandBus()
+            >>> bus.register_handler(PrintCommand, PrintCommandHandler())
+            >>>
+            >>> bus.is_registered(PrintCommand)
+            True
+        """
         _validate_handler(command_type, handler)
 
         self._handlers[command_type] = handler
 
     @typechecked
     def remove_handler(self, command_type: Type[SpecificCommand]) -> None:
-        """Remove a previously registered handler."""
+        """Remove a previously registered handler.
+
+        Example:
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
+            >>> bus = CommandBus()
+            >>> bus.register_handler(PrintCommand, PrintCommandHandler())
+            >>>
+            >>> bus.remove_handler(PrintCommand)
+            >>> bus.is_registered(PrintCommand)
+            False
+        """
         if command_type not in self._handlers:
             raise MissingHandlerError(
                 f"A handler has not been registered for the command '{command_type.__name__}'"
@@ -93,7 +112,16 @@ class CommandBus:
         del self._handlers[command_type]
 
     def is_registered(self, command_type: Type[SpecificCommand]) -> bool:
-        """Checks if a command is registered with the bus."""
+        """Checks if a command is registered with the bus.
+
+        Example:
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
+            >>> bus = CommandBus()
+            >>> bus.register_handler(PrintCommand, PrintCommandHandler())
+            >>>
+            >>> bus.is_registered(PrintCommand)
+            True
+        """
         if command_type in self._handlers:
             return True
 

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -58,7 +58,18 @@ class EventBus:
         event_type: Type[Event],
         handlers: Sequence[SupportsHandle],
     ) -> None:
-        """Register handlers that will dispatch a type of Event."""
+        """Register handlers that will dispatch a type of Event.
+
+        Handlers must be objects with a handle() method.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
+            >>> bus = EventBus()
+            >>> bus.add_handlers(ExampleEvent, [ExampleEventHandler(), OtherEventHandler()])
+            >>>
+            >>> bus.has_handlers(ExampleEvent)
+            2
+        """
         for handler in handlers:  # pragma: no branch
             _validate_handler(handler)
             self._handlers[event_type].append(handler)
@@ -69,7 +80,32 @@ class EventBus:
         event_type: Type[Event],
         handlers: Sequence[SupportsHandle] | None = None,
     ) -> None:
-        """Remove previously registered handlers."""
+        """Remove previously registered handlers.
+
+        If handlers are provided, only these will be removed.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
+            >>> bus = EventBus()
+            >>> handler1 = ExampleEventHandler()
+            >>> bus.add_handlers(ExampleEvent, [handler1, OtherEventHandler()])
+            >>>
+            >>> bus.remove_handlers(ExampleEvent, [handler1])
+            >>> bus.has_handlers(ExampleEvent)
+            1
+
+        Defaults to removing all handlers for an event if no handlers are provided.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
+            >>> bus = EventBus()
+            >>> handler1 = ExampleEventHandler()
+            >>> bus.add_handlers(ExampleEvent, [handler1, OtherEventHandler()])
+            >>>
+            >>> bus.remove_handlers(ExampleEvent)
+            >>> bus.has_handlers(ExampleEvent)
+            0
+        """
         if handlers is None:
             handlers = []
 
@@ -87,7 +123,16 @@ class EventBus:
             self._handlers[event_type] = []
 
     def has_handlers(self, event_type: Type[Event]) -> int:
-        """Returns the number of handlers registered for a type of event."""
+        """Returns the number of handlers registered for a type of event.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler
+            >>> bus = EventBus()
+            >>> bus.add_handlers(ExampleEvent, [ExampleEventHandler()])
+            >>>
+            >>> bus.has_handlers(ExampleEvent)
+            1
+        """
         return len(self._handlers[event_type])
 
     @typechecked

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -86,11 +86,8 @@ class EventBus:
         if len(handlers) == 0:  # pragma: no branch
             self._handlers[event_type] = []
 
-    def has_handlers(
-        self,
-        event_type: Type[Event],
-    ) -> int:
-        """Remove previously registered handlers."""
+    def has_handlers(self, event_type: Type[Event]) -> int:
+        """Returns the number of handlers registered for a type of event."""
         return len(self._handlers[event_type])
 
     @typechecked

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -86,6 +86,13 @@ class EventBus:
         if len(handlers) == 0:  # pragma: no branch
             self._handlers[event_type] = []
 
+    def has_handlers(
+        self,
+        event_type: Type[Event],
+    ) -> int:
+        """Remove previously registered handlers."""
+        return len(self._handlers[event_type])
+
     @typechecked
     def dispatch(
         self, event: Event, handlers: Sequence[SupportsHandle] | None = None

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -113,3 +113,11 @@ class MessageBus:
     def deregister_command(self, message_type: Type[SpecificCommand]) -> None:
         """Remove a handler that is registered to execute a Command."""
         self.command_bus.remove_handler(message_type)
+
+    def has_handlers(self, event_type: Type[Event]) -> int:
+        """Returns the number of handlers registered for a type of event."""
+        return self.event_bus.has_handlers(event_type)
+
+    def is_registered(self, command_type: Type[SpecificCommand]) -> bool:
+        """Checks if a command is registered with the command bus."""
+        return self.command_bus.is_registered(command_type)

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -115,9 +115,27 @@ class MessageBus:
         self.command_bus.remove_handler(message_type)
 
     def has_handlers(self, event_type: Type[Event]) -> int:
-        """Returns the number of handlers registered for a type of event."""
+        """Returns the number of handlers registered for a type of event.
+
+        Example:
+            >>> from tests.examples import ExampleEvent, ExampleEventHandler
+            >>> bus = MessageBus()
+            >>> bus.register_event(ExampleEvent, [ExampleEventHandler])
+            >>>
+            >>> bus.has_handlers(ExampleEvent)
+            1
+        """
         return self.event_bus.has_handlers(event_type)
 
     def is_registered(self, command_type: Type[SpecificCommand]) -> bool:
-        """Checks if a command is registered with the command bus."""
+        """Returns whether a command is registered with the command bus.
+
+        Example:
+            >>> from tests.examples import PrintCommand, PrintCommandHandler
+            >>> bus = MessageBus()
+            >>> bus.register_command(PrintCommand, PrintCommandHandler)
+            >>>
+            >>> bus.is_registered(PrintCommand)
+            True
+        """
         return self.command_bus.is_registered(command_type)

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -22,6 +22,13 @@ class ExampleEventHandler(SupportsHandle):
         event.print_event_data()
 
 
+class OtherEventHandler(SupportsHandle):
+    """An event handler purely for use in tests."""
+
+    def handle(self, event: ExampleEvent) -> None:
+        """Handle a test event."""
+
+
 class PrintCommand(Command):
     """A command purely for use in tests."""
 

--- a/tests/loader/test_lagom_loader.py
+++ b/tests/loader/test_lagom_loader.py
@@ -1,7 +1,13 @@
-from lagom import Container
+import pytest
 
-from boss_bus.loader.lagom_loader import LagomLoader
 from tests.loader.examples import CustomDeps, LayeredDeps, NoDeps
+
+try:
+    from lagom import Container
+
+    from boss_bus.loader.lagom_loader import LagomLoader
+except ImportError:  # pragma: no cover
+    pytest.skip("lagom dependency not installed", allow_module_level=True)
 
 
 class TestClassInstantiator:

--- a/tests/test_command_bus.py
+++ b/tests/test_command_bus.py
@@ -201,3 +201,23 @@ class TestCommandBus:
 
         with pytest.raises(MissingHandlerError):
             bus.remove_handler(ExplosionCommand)
+
+    def test_is_registered_returns_false_for_non_registered_command(
+        self,
+    ) -> None:
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.register_handler(ExplosionCommand, handler)
+
+        assert bus.is_registered(FloodCommand) is False
+
+    def test_is_registered_returns_true_for_registered_command(
+        self,
+    ) -> None:
+        handler = ExplosionCommandHandler()
+        bus = CommandBus()
+
+        bus.register_handler(ExplosionCommand, handler)
+
+        assert bus.is_registered(ExplosionCommand) is True

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -12,6 +12,8 @@ from boss_bus.event_bus import (
 from boss_bus.handler import MissingHandlerError
 from boss_bus.interface import SupportsHandle
 
+from .examples import ExampleEvent
+
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
@@ -198,3 +200,24 @@ class TestEventBus:
         bus = EventBus()
 
         bus.remove_handlers(ExplosionEvent)
+
+    def test_has_handlers_returns_false_for_non_registered_command(
+        self,
+    ) -> None:
+        bus = EventBus()
+        handler1 = ExplosionEventHandler()
+
+        bus.add_handlers(ExplosionEvent, [handler1])
+
+        assert bus.has_handlers(ExampleEvent) == 0
+
+    def test_has_handlers_returns_number_of_registered_handlers(
+        self,
+    ) -> None:
+        bus = EventBus()
+        handler1 = ExplosionEventHandler()
+        handler2 = SecondExplosionEventHandler()
+
+        bus.add_handlers(ExplosionEvent, [handler1, handler2])
+
+        assert bus.has_handlers(ExplosionEvent) == 2

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -99,6 +99,16 @@ class TestMessageBus:
 
         assert handler not in event_bus._handlers.get(ExampleEvent, [])  # noqa: SLF001
 
+    def test_is_registered_returns_false_for_command_not_registered(self) -> None:
+        bus = MessageBus()
+
+        assert bus.is_registered(ReturnCommand) is False
+
+    def test_has_handlers_returns_zero_for_event_not_registered(self) -> None:
+        bus = MessageBus()
+
+        assert bus.has_handlers(ExampleEvent) == 0
+
     def test_default_loader_instantiates_event_classes(
         self, capsys: CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
New methods `has_handlers` and `is_registered` have been added to check for registered events and commands, respectively. `has_handlers` returns the number of handlers and `is_registered` returns True or False.

Examples have also been added to existing methods.