### PR TITLE
De-register Events using Handler Classes or Instances

### DIFF
--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -82,7 +82,7 @@ class EventBus:
     ) -> None:
         """Remove previously registered handlers.
 
-        If handlers are provided, only these will be removed.
+        If handlers are provided, handlers of this class will be removed.
 
         Example:
             >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
@@ -107,9 +107,10 @@ class EventBus:
             0
         """
         if handlers is None:
-            handlers = []
+            self._handlers[event_type] = []
+            return
 
-        for handler in handlers:
+        for handler in handlers:  # pragma: no branch
             _validate_handler(handler)
 
             matching_handlers = [
@@ -118,15 +119,13 @@ class EventBus:
                 if type(handler) == type(registered_handler)
             ]
 
-            if matching_handlers:
-                self._handlers[event_type].remove(matching_handlers[0])
-            else:
+            if not matching_handlers:
                 raise MissingHandlerError(
                     f"The handler '{handler}' has not been registered for event '{event_type.__name__}'"
                 )
 
-        if len(handlers) == 0:  # pragma: no branch
-            self._handlers[event_type] = []
+            for matched_handler in matching_handlers:
+                self._handlers[event_type].remove(matched_handler)
 
     def has_handlers(self, event_type: Type[Event]) -> int:
         """Returns the number of handlers registered for a type of event.

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -112,12 +112,18 @@ class EventBus:
         for handler in handlers:
             _validate_handler(handler)
 
-            if handler not in self._handlers[event_type]:
+            matching_handlers = [
+                registered_handler
+                for registered_handler in self._handlers[event_type]
+                if type(handler) == type(registered_handler)
+            ]
+
+            if matching_handlers:
+                self._handlers[event_type].remove(matching_handlers[0])
+            else:
                 raise MissingHandlerError(
                     f"The handler '{handler}' has not been registered for event '{event_type.__name__}'"
                 )
-
-            self._handlers[event_type].remove(handler)
 
         if len(handlers) == 0:  # pragma: no branch
             self._handlers[event_type] = []

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -128,10 +128,6 @@ class MessageBus:
     ) -> None:
         """Remove handlers that are registered to dispatch an Event.
 
-        Todo:
-            * Allow uninstantiated classes like register
-            * Match handler based on type, not instance
-
         If handlers are provided, only these will be removed.
 
         Example:

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -118,12 +118,13 @@ class MessageBus:
             True
         """
         loaded_handler = self.loader.load(handler)
+
         self.command_bus.register_handler(message_type, loaded_handler)
 
     def deregister_event(
         self,
         message_type: Type[Event],
-        handlers: Sequence[SupportsHandle] | None = None,
+        handlers: Sequence[Type[SupportsHandle] | SupportsHandle] | None = None,
     ) -> None:
         """Remove handlers that are registered to dispatch an Event.
 
@@ -136,10 +137,10 @@ class MessageBus:
         Example:
             >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
             >>> bus = MessageBus()
-            >>> handler = ExampleEventHandler()
-            >>> bus.register_event(ExampleEvent, [handler, OtherEventHandler])
+            >>> example_handler = ExampleEventHandler()
+            >>> bus.register_event(ExampleEvent, [example_handler, OtherEventHandler])
             >>>
-            >>> bus.deregister_event(ExampleEvent, [handler])
+            >>> bus.deregister_event(ExampleEvent, [OtherEventHandler])
             >>> bus.has_handlers(ExampleEvent)
             1
 
@@ -148,14 +149,18 @@ class MessageBus:
         Example:
             >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
             >>> bus = MessageBus()
-            >>> handler = ExampleEventHandler()
             >>> bus.register_event(ExampleEvent, [ExampleEventHandler, OtherEventHandler])
             >>>
             >>> bus.deregister_event(ExampleEvent)
             >>> bus.has_handlers(ExampleEvent)
             0
         """
-        self.event_bus.remove_handlers(message_type, handlers)
+        if handlers is None:
+            handlers = []
+
+        loaded_handlers = [self.loader.load(handler) for handler in handlers]
+
+        self.event_bus.remove_handlers(message_type, loaded_handlers)
 
     def deregister_command(self, message_type: Type[SpecificCommand]) -> None:
         """Remove a handler that is registered to execute a Command.

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -128,7 +128,7 @@ class MessageBus:
     ) -> None:
         """Remove handlers that are registered to dispatch an Event.
 
-        If handlers are provided, only these will be removed.
+        If handlers are provided, handlers of that class will be removed.
 
         Example:
             >>> from tests.examples import ExampleEvent, ExampleEventHandler, OtherEventHandler
@@ -152,11 +152,10 @@ class MessageBus:
             0
         """
         if handlers is None:
-            handlers = []
+            return self.event_bus.remove_handlers(message_type)
 
         loaded_handlers = [self.loader.load(handler) for handler in handlers]
-
-        self.event_bus.remove_handlers(message_type, loaded_handlers)
+        return self.event_bus.remove_handlers(message_type, loaded_handlers)
 
     def deregister_command(self, message_type: Type[SpecificCommand]) -> None:
         """Remove a handler that is registered to execute a Command.

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -201,6 +201,17 @@ class TestEventBus:
 
         bus.remove_handlers(ExplosionEvent)
 
+    def test_remove_handlers_matches_based_on_type_not_instance(self) -> None:
+        handler1 = ExplosionEventHandler()
+        handler2 = ExplosionEventHandler()
+        bus = EventBus()
+
+        bus.add_handlers(ExplosionEvent, [handler1])
+
+        bus.remove_handlers(ExplosionEvent, [handler2])
+
+        assert bus.has_handlers(ExplosionEvent) == 0
+
     def test_has_handlers_returns_false_for_non_registered_command(
         self,
     ) -> None:

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -8,6 +8,7 @@ from boss_bus.message_bus import MessageBus
 from tests.examples import (
     ExampleEvent,
     ExampleEventHandler,
+    OtherEventHandler,
     PrintCommand,
     PrintCommandHandler,
     ReturnCommand,
@@ -132,3 +133,11 @@ class TestMessageBus:
 
         captured = capsys.readouterr()
         assert captured.out == "Testing...\n"
+
+    def test_default_loader_can_be_used_to_deregister_events(self) -> None:
+        bus = MessageBus()
+
+        bus.register_event(ExampleEvent, [ExampleEventHandler(), OtherEventHandler()])
+        bus.deregister_event(ExampleEvent, [ExampleEventHandler])
+
+        assert bus.has_handlers(ExampleEvent) == 1

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -100,6 +100,16 @@ class TestMessageBus:
 
         assert handler not in event_bus._handlers.get(ExampleEvent, [])  # noqa: SLF001
 
+    def test_all_events_deregister_if_no_handlers_provided(self) -> None:
+        event_bus = EventBus()
+        bus = MessageBus(event_bus=event_bus)
+
+        bus.register_event(ExampleEvent, [ExampleEventHandler, OtherEventHandler])
+
+        bus.deregister_event(ExampleEvent)
+
+        assert bus.has_handlers(ExampleEvent) == 0
+
     def test_is_registered_returns_false_for_command_not_registered(self) -> None:
         bus = MessageBus()
 


### PR DESCRIPTION
Event handlers can now be de-registered by passing the instance as an object or an uninstantiated class; similar to registering. This means that the handlers are now matched using their type when de-registering, rather than their object identity