### PR TITLE
Add Middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boss-bus"
-version = "0.3.0"
+version = "0.4.0"
 description = "A Type-driven Message Bus for Python 3.8+"
 authors = ["Jim Dickinson <james.n.dickinson@gmail.com>"]
 license = "GPL-3.0"

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -16,12 +16,12 @@ from typing import Any, Generic, Type, TypeVar
 from typeguard import typechecked
 
 from boss_bus.handler import MissingHandlerError
-from boss_bus.interface import SupportsHandle
+from boss_bus.interface import Message, SupportsHandle
 
 from ._utils.typing import get_annotations, type_matches
 
 
-class Command:
+class Command(Message):
     """A form of message which only has one handler."""
 
 

--- a/src/boss_bus/command_bus.py
+++ b/src/boss_bus/command_bus.py
@@ -24,6 +24,8 @@ from ._utils.typing import get_annotations, type_matches
 class Command(Message):
     """A form of message which only has one handler."""
 
+    message_type: str = "command"
+
 
 SpecificCommand = TypeVar("SpecificCommand", bound=Command)
 

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -11,16 +11,19 @@ Classes:
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Sequence, Type
+from typing import Any, Sequence, Type, TypeVar
 
 from typeguard import TypeCheckError, typechecked
 
 from boss_bus.handler import MissingHandlerError
-from boss_bus.interface import SupportsHandle
+from boss_bus.interface import Message, SupportsHandle
 
 
-class Event:
+class Event(Message):
     """A form of message which can have multiple handlers."""
+
+
+SpecificEvent = TypeVar("SpecificEvent", bound=Event)
 
 
 class MissingEventError(Exception):

--- a/src/boss_bus/event_bus.py
+++ b/src/boss_bus/event_bus.py
@@ -22,6 +22,8 @@ from boss_bus.interface import Message, SupportsHandle
 class Event(Message):
     """A form of message which can have multiple handlers."""
 
+    message_type: str = "event"
+
 
 SpecificEvent = TypeVar("SpecificEvent", bound=Event)
 

--- a/src/boss_bus/interface.py
+++ b/src/boss_bus/interface.py
@@ -7,11 +7,19 @@ Classes:
 
 from __future__ import annotations
 
+from abc import ABC
 from typing import Any, Protocol, TypeVar, runtime_checkable
 
 
-class Message:
+class Message(ABC):
     """An abstract DTO for use with handlers."""
+
+    message_type: str = "message"
+
+    @property
+    def message_name(self) -> str:
+        """Defines the name of a message being logged."""
+        return type(self).__name__
 
 
 SpecificMessage = TypeVar("SpecificMessage", bound=Message)

--- a/src/boss_bus/interface.py
+++ b/src/boss_bus/interface.py
@@ -7,7 +7,14 @@ Classes:
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+
+class Message:
+    """An abstract DTO for use with handlers."""
+
+
+SpecificMessage = TypeVar("SpecificMessage", bound=Message)
 
 
 @runtime_checkable

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -15,11 +15,10 @@ from boss_bus.command_bus import (
     CommandHandler,
     SpecificCommand,
 )
-from boss_bus.event_bus import Event, EventBus
+from boss_bus.event_bus import Event, EventBus, SpecificEvent
 from boss_bus.interface import SupportsHandle  # noqa: TCH001
 from boss_bus.loader.instantiator import ClassInstantiator
 from boss_bus.middleware.log import (
-    LoggingMessage,
     MessageLogger,
 )
 
@@ -69,12 +68,11 @@ class MessageBus:
             >>> bus.execute(test_command, test_handler)
             Testing...
         """
-        if not isinstance(command, LoggingMessage):
-            return self.command_bus.execute(command, handler)
 
-        def loaded_bus(c: SpecificCommand | LoggingMessage) -> Any:  # type: ignore[unreachable]
+        def loaded_bus(c: SpecificCommand) -> Any:
             return self.command_bus.execute(c, handler)
 
+        # noinspection PyTypeChecker
         return self.logger.handle(command, loaded_bus)
 
     def dispatch(
@@ -91,13 +89,11 @@ class MessageBus:
             >>> bus.dispatch(test_event, [test_handler])
             Testing...
         """
-        if not isinstance(event, LoggingMessage):
-            self.event_bus.dispatch(event, handlers)
-            return
 
-        def loaded_bus(e: Event | LoggingMessage) -> None:
-            return self.event_bus.dispatch(e, handlers)  # type: ignore[arg-type]
+        def loaded_bus(e: SpecificEvent) -> None:
+            return self.event_bus.dispatch(e, handlers)
 
+        # noinspection PyTypeChecker
         self.logger.handle(event, loaded_bus)
 
     def register_event(

--- a/src/boss_bus/middleware/__init__.py
+++ b/src/boss_bus/middleware/__init__.py
@@ -1,0 +1,6 @@
+"""Provide the ability to augment or supplement message handling."""
+
+from boss_bus.middleware.log import MessageLogger
+from boss_bus.middleware.middleware import Middleware
+
+DEFAULT_MIDDLEWARE: list[Middleware] = [MessageLogger()]

--- a/src/boss_bus/middleware/__init__.py
+++ b/src/boss_bus/middleware/__init__.py
@@ -1,6 +1,7 @@
 """Provide the ability to augment or supplement message handling."""
+from typing import List
 
 from boss_bus.middleware.log import MessageLogger
 from boss_bus.middleware.middleware import Middleware
 
-DEFAULT_MIDDLEWARE: list[Middleware] = [MessageLogger()]
+DEFAULT_MIDDLEWARE: List[Middleware] = [MessageLogger()]

--- a/src/boss_bus/middleware/log.py
+++ b/src/boss_bus/middleware/log.py
@@ -1,0 +1,78 @@
+"""Enable automated logging within message handling."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from typing import Any, Callable, ClassVar
+
+
+class LoggingMessage(ABC):
+    """A form of message that submits logs when being handled."""
+
+    message_type: str = "message"
+    message_verbs: ClassVar[list[str]] = ["handle", "handled", "handling"]
+
+    @property
+    def message_name(self) -> str:
+        """Defines the name of a message being logged."""
+        return type(self).__name__
+
+    def pre_handle_log(self) -> str:
+        """Creates some text to be logged before handling."""
+        handling = self.message_verbs[2].capitalize()
+        message = self.message_type
+        name = self.message_name
+        return f"{handling} {message} <{name}>"
+
+    def post_handle_log(self) -> str:
+        """Creates some text to be logged after handling."""
+        handled = self.message_verbs[1]
+        message = self.message_type
+        name = self.message_name
+        return f"Successfully {handled} {message} <{name}>"
+
+    def error_log(self) -> str:
+        """Creates some text to be logged if an error is raised."""
+        handling = self.message_verbs[2]
+        message = self.message_type
+        name = self.message_name
+        return f"Failed {handling} {message} <{name}>"
+
+
+class LoggingCommand(LoggingMessage):
+    """A form of command that submits logs when being handled."""
+
+    message_type: str = "command"
+    message_verbs: ClassVar[list[str]] = ["execute", "executed", "executing"]
+
+
+class LoggingEvent(LoggingMessage):
+    """A form of event that submits logs when being handled."""
+
+    message_type: str = "event"
+    message_verbs: ClassVar[list[str]] = ["dispatch", "dispatched", "dispatching"]
+
+
+class MessageLogger:
+    """Connects a logger to be used for automated message logging."""
+
+    def __init__(self, logger: logging.Logger | None = None):
+        """Creates a MessageLogger that automates logging during message handling."""
+        self.logger = logger if logger is not None else logging.getLogger()
+
+    def handle(
+        self, message: LoggingMessage, loaded_bus: Callable[[LoggingMessage], Any]
+    ) -> Any:
+        """Submits logs and handles messages."""
+        self.logger.info(message.pre_handle_log())
+
+        try:
+            result = loaded_bus(message)
+        except Exception:
+            self.logger.exception(message.error_log())
+            raise
+
+        self.logger.info(message.post_handle_log())
+
+        return result

--- a/src/boss_bus/middleware/log.py
+++ b/src/boss_bus/middleware/log.py
@@ -6,6 +6,8 @@ import logging
 from abc import ABC
 from typing import Any, Callable, ClassVar, cast
 
+from boss_bus.command_bus import Command
+from boss_bus.event_bus import Event
 from boss_bus.interface import Message, SpecificMessage
 from boss_bus.middleware.middleware import Middleware
 
@@ -13,13 +15,7 @@ from boss_bus.middleware.middleware import Middleware
 class LoggingMessage(Message, ABC):
     """A form of message that submits logs when being handled."""
 
-    message_type: str = "message"
     message_verbs: ClassVar[list[str]] = ["handle", "handled", "handling"]
-
-    @property
-    def message_name(self) -> str:
-        """Defines the name of a message being logged."""
-        return type(self).__name__
 
     def pre_handle_log(self) -> str:
         """Creates some text to be logged before handling."""
@@ -43,17 +39,15 @@ class LoggingMessage(Message, ABC):
         return f"Failed {handling} {message} <{name}>"
 
 
-class LoggingCommand(LoggingMessage):
+class LoggingCommand(LoggingMessage, Command):
     """A form of command that submits logs when being handled."""
 
-    message_type: str = "command"
     message_verbs: ClassVar[list[str]] = ["execute", "executed", "executing"]
 
 
-class LoggingEvent(LoggingMessage):
+class LoggingEvent(LoggingMessage, Event):
     """A form of event that submits logs when being handled."""
 
-    message_type: str = "event"
     message_verbs: ClassVar[list[str]] = ["dispatch", "dispatched", "dispatching"]
 
 

--- a/src/boss_bus/middleware/middleware.py
+++ b/src/boss_bus/middleware/middleware.py
@@ -1,7 +1,5 @@
-"""Classes that load dependencies and use them to instantiate classes.
+"""Interfaces for classes that augment or supplement message handling."""
 
-Class loading classes should implement the Interface (ClassLoader)
-"""
 from __future__ import annotations
 
 from functools import partial

--- a/src/boss_bus/middleware/middleware.py
+++ b/src/boss_bus/middleware/middleware.py
@@ -4,12 +4,13 @@ Class loading classes should implement the Interface (ClassLoader)
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from boss_bus.interface import SpecificMessage
 
 
+@runtime_checkable
 class Middleware(Protocol):
     """Performs actions before or after message handling."""
 

--- a/src/boss_bus/middleware/middleware.py
+++ b/src/boss_bus/middleware/middleware.py
@@ -4,10 +4,10 @@ Class loading classes should implement the Interface (ClassLoader)
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
+from functools import partial
+from typing import Any, Callable, Protocol, runtime_checkable
 
-if TYPE_CHECKING:
-    from boss_bus.interface import SpecificMessage
+from boss_bus.interface import SpecificMessage  # noqa: TCH001
 
 
 @runtime_checkable
@@ -20,3 +20,23 @@ class Middleware(Protocol):
         next_middleware: Callable[[SpecificMessage], Any],
     ) -> Any:
         """Perform actions before or after message handling."""
+
+
+def create_middleware_chain(
+    bus_closure: Callable[[SpecificMessage], Any],
+    middlewares: list[Middleware],
+) -> Callable[[SpecificMessage], Any]:
+    """Creates a chain of middleware finishing with a bus."""
+
+    def middleware_closure(
+        current_middleware: Middleware,
+        next_closure: Callable[[SpecificMessage], Any],
+        message: SpecificMessage,
+    ) -> Any:
+        return current_middleware.handle(message, next_closure)
+
+    next_middleware = bus_closure
+    for middleware in reversed(middlewares):
+        next_middleware = partial(middleware_closure, middleware, next_middleware)
+
+    return next_middleware

--- a/src/boss_bus/middleware/middleware.py
+++ b/src/boss_bus/middleware/middleware.py
@@ -1,0 +1,21 @@
+"""Classes that load dependencies and use them to instantiate classes.
+
+Class loading classes should implement the Interface (ClassLoader)
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Protocol
+
+if TYPE_CHECKING:
+    from boss_bus.interface import SpecificMessage
+
+
+class Middleware(Protocol):
+    """Performs actions before or after message handling."""
+
+    def handle(
+        self,
+        message: SpecificMessage,
+        next_middleware: Callable[[SpecificMessage], Any],
+    ) -> Any:
+        """Perform actions before or after message handling."""

--- a/tests/middleware/examples.py
+++ b/tests/middleware/examples.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+from boss_bus.command_bus import Command, CommandHandler
+from boss_bus.event_bus import Event
+from boss_bus.interface import SupportsHandle
+from boss_bus.middleware.log import LoggingCommand, LoggingEvent
+
+
+class LogTestCommand(Command, LoggingCommand):
+    def __init__(self, command_data: str):
+        """Creates a command for tests."""
+        self.command_data = command_data
+
+    def log_command_data(self) -> None:
+        logging.info(self.command_data)
+
+
+class LogErrorCommand(LogTestCommand):
+    def log_command_data(self) -> None:
+        raise Exception
+
+
+class LoggingCommandHandler(CommandHandler[LogTestCommand]):
+    def handle(self, command: LogTestCommand) -> None:
+        command.log_command_data()
+
+
+class LogTestEvent(Event, LoggingEvent):
+    def __init__(self, event_data: str):
+        """Creates an event for tests."""
+        self.event_data = event_data
+
+    def log_event_data(self) -> None:
+        logging.info(self.event_data)
+
+
+class LogErrorEvent(LogTestEvent):
+    def log_event_data(self) -> None:
+        raise Exception
+
+
+class LoggingEventHandler(SupportsHandle):
+    def handle(self, event: LogTestEvent) -> None:
+        event.log_event_data()

--- a/tests/middleware/examples.py
+++ b/tests/middleware/examples.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import logging
 
-from boss_bus.command_bus import Command, CommandHandler
-from boss_bus.event_bus import Event
+from boss_bus.command_bus import CommandHandler
 from boss_bus.interface import SupportsHandle
 from boss_bus.middleware.log import LoggingCommand, LoggingEvent
 
 
-class LogTestCommand(Command, LoggingCommand):
+class LogTestCommand(LoggingCommand):
     def __init__(self, command_data: str):
         """Creates a command for tests."""
         self.command_data = command_data
@@ -27,7 +26,7 @@ class LoggingCommandHandler(CommandHandler[LogTestCommand]):
         command.log_command_data()
 
 
-class LogTestEvent(Event, LoggingEvent):
+class LogTestEvent(LoggingEvent):
     def __init__(self, event_data: str):
         """Creates an event for tests."""
         self.event_data = event_data

--- a/tests/middleware/test_log.py
+++ b/tests/middleware/test_log.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from tests.middleware.examples import (
+    LogErrorCommand,
+    LogErrorEvent,
+    LoggingCommandHandler,
+    LoggingEventHandler,
+    LogTestCommand,
+    LogTestEvent,
+)
+
+from boss_bus.middleware.log import LoggingMessage, MessageLogger
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+
+
+class TestLog:
+    def test_message_logger_logs_before_and_after_message(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        logger = MessageLogger()
+        command = LogTestCommand("Logging...")
+
+        def bus(c: LoggingMessage) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        logger.handle(command, bus)
+
+        assert len(caplog.record_tuples) == 3
+        assert caplog.record_tuples[1][2] == "Logging..."
+
+    def test_a_custom_logger_can_be_provided(self, caplog: LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO)
+        custom_logger = logging.getLogger("test")
+        logger = MessageLogger(custom_logger)
+        command = LogTestCommand("Logging...")
+
+        def bus(c: LoggingMessage) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        logger.handle(command, bus)
+
+        assert caplog.record_tuples[0][0] == "test"
+
+    def test_commands_log_with_correct_verbs(self, caplog: LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO)
+        logger = MessageLogger()
+        command = LogTestCommand("Logging...")
+
+        def bus(c: LoggingMessage) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        logger.handle(command, bus)
+
+        assert "executing" in caplog.record_tuples[0][2].lower()
+        assert "command" in caplog.record_tuples[0][2].lower()
+        assert "executed" in caplog.record_tuples[2][2].lower()
+        assert "command" in caplog.record_tuples[2][2].lower()
+
+    def test_events_log_with_correct_verbs(self, caplog: LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO)
+        logger = MessageLogger()
+        event = LogTestEvent("Logging...")
+
+        def bus(c: LoggingMessage) -> Any:
+            LoggingEventHandler().handle(c)  # type: ignore[arg-type]
+
+        logger.handle(event, bus)
+
+        assert "dispatching" in caplog.record_tuples[0][2].lower()
+        assert "event" in caplog.record_tuples[0][2].lower()
+        assert "dispatched" in caplog.record_tuples[2][2].lower()
+        assert "event" in caplog.record_tuples[2][2].lower()
+
+    def test_commands_log_if_an_error_is_raised(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        logger = MessageLogger()
+        command: LoggingMessage = LogErrorCommand("Logging...")
+
+        def bus(c: LoggingMessage) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            logger.handle(command, bus)
+
+        print(caplog.record_tuples)
+        assert len(caplog.record_tuples) == 2
+        assert "Failed executing" in caplog.record_tuples[1][2]
+
+    def test_events_log_if_an_error_is_raised(self, caplog: LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO)
+        logger = MessageLogger()
+        event = LogErrorEvent("Logging...")
+
+        def bus(e: LoggingMessage) -> Any:
+            LoggingEventHandler().handle(e)  # type: ignore[arg-type]
+
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            logger.handle(event, bus)
+
+        print(caplog.record_tuples)
+        assert len(caplog.record_tuples) == 2
+        assert "Failed dispatching" in caplog.record_tuples[1][2]

--- a/tests/middleware/test_middleware_message_bus.py
+++ b/tests/middleware/test_middleware_message_bus.py
@@ -1,0 +1,57 @@
+import logging
+
+from _pytest.logging import LogCaptureFixture
+from tests.examples import (
+    ExampleEvent,
+    ExampleEventHandler,
+    PrintCommand,
+    PrintCommandHandler,
+)
+from tests.middleware.examples import (
+    LoggingCommandHandler,
+    LoggingEventHandler,
+    LogTestCommand,
+    LogTestEvent,
+)
+
+from boss_bus.message_bus import MessageBus
+
+
+class TestMessageBusLogger:
+    def test_log_commands_log_before_and_after_execution(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        bus = MessageBus()
+
+        bus.execute(LogTestCommand("Logging..."), LoggingCommandHandler())
+        assert len(caplog.record_tuples) == 3
+        assert caplog.record_tuples[1][2] == "Logging..."
+
+    def test_none_log_commands_do_not_log_messages(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        bus = MessageBus()
+
+        bus.execute(PrintCommand("Logging..."), PrintCommandHandler())
+        assert len(caplog.record_tuples) == 0
+
+    def test_log_events_log_before_and_after_execution(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        bus = MessageBus()
+
+        bus.dispatch(LogTestEvent("Logging..."), [LoggingEventHandler()])
+        assert len(caplog.record_tuples) == 3
+        assert caplog.record_tuples[1][2] == "Logging..."
+
+    def test_none_log_events_do_not_log_messages(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+        bus = MessageBus()
+
+        bus.dispatch(ExampleEvent("Logging..."), [ExampleEventHandler()])
+        assert len(caplog.record_tuples) == 0

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -62,7 +62,7 @@ class TestMessageBus:
         bus = MessageBus()
 
         with pytest.raises(TypeCheckError):
-            bus.dispatch(command, handler)  # type: ignore[arg-type]
+            bus.dispatch(command, handler)  # type: ignore[arg-type, type-var]
 
     def test_command_registers_with_the_command_bus(self) -> None:
         handler = PrintCommandHandler()


### PR DESCRIPTION
Create a new interface `Middleware`. These classes perform additional actions when events or commands are handled. Currently, the only implementation is a logger, as explained below, but custom middleware can be provided to the message bus upon instantiation.

Multiple middleware form a chain which finishes with the event or command bus (depending on the message provided). This chain will perform additional actions in a specific order before or after handling of the message.

The intention is that middleware can be applied to a message bus but will not do anything with a message unless the message implements a required interface.

## MessageLogger
The `MessageLogger` implementation of Middleware will log messages before and after successful handling of a message that extends `LoggingCommand`, `LoggingEvent` or `LoggingMessage`. If an error is raised, the 'after' message is replaced by an error message. The error messages can be customised by overriding methods on the logging classes.

A Logger from the logging library can be passed to the MessageLogger or by default it uses the root Logger.