### PR TITLE
Add Locking Middleware

### DIFF
--- a/src/boss_bus/loader/__init__.py
+++ b/src/boss_bus/loader/__init__.py
@@ -13,6 +13,10 @@ obj = TypeVar("obj", bound=object)
 class ClassLoader(ABC):
     """An Interface that allows loading dependencies and instantiating classes."""
 
+    @abstractmethod
+    def add_dependency(self, dependency: object) -> None:
+        """Add an already instantiated object dependency that can be retrieved."""
+
     @overload
     def load(self, cls: Type[obj]) -> obj:
         pass
@@ -23,4 +27,4 @@ class ClassLoader(ABC):
 
     @abstractmethod
     def load(self, cls: Type[obj] | obj) -> obj:
-        """Instantiates a class or returns an already instantiated instance."""
+        """Instantiates a class or returns an already instantiated object."""

--- a/src/boss_bus/loader/instantiator.py
+++ b/src/boss_bus/loader/instantiator.py
@@ -27,6 +27,10 @@ class ClassInstantiator(ClassLoader):
         """Creates an object that instantiates simple dependencies."""
         self.dependencies = list(dependencies)
 
+    def add_dependency(self, dependency: object) -> None:
+        """Add an already instantiated object dependency that can be retrieved."""
+        self.dependencies.append(dependency)
+
     @overload
     def load(self, cls: Type[obj]) -> obj:
         pass

--- a/src/boss_bus/message_bus.py
+++ b/src/boss_bus/message_bus.py
@@ -47,6 +47,7 @@ class MessageBus:
     ):
         """Creates a Message Bus."""
         self.loader = class_loader if class_loader is not None else ClassInstantiator()
+        self.loader.add_dependency(self)
         self.middleware = middleware if middleware is not None else DEFAULT_MIDDLEWARE
         self.command_bus = command_bus if command_bus is not None else CommandBus()
         self.event_bus = event_bus if event_bus is not None else EventBus()

--- a/src/boss_bus/middleware/__init__.py
+++ b/src/boss_bus/middleware/__init__.py
@@ -1,7 +1,8 @@
 """Provide the ability to augment or supplement message handling."""
 from typing import List
 
+from boss_bus.middleware.lock import BusLocker
 from boss_bus.middleware.log import MessageLogger
 from boss_bus.middleware.middleware import Middleware
 
-DEFAULT_MIDDLEWARE: List[Middleware] = [MessageLogger()]
+DEFAULT_MIDDLEWARE: List[Middleware] = [BusLocker(), MessageLogger()]

--- a/src/boss_bus/middleware/lock.py
+++ b/src/boss_bus/middleware/lock.py
@@ -70,7 +70,7 @@ class BusLocker(Middleware):
 
             self._wait_for_unlock()
 
-        if not getattr(message, self.message_id, False):
+        if not self.message_applicable(message):
             return next_middleware(message)
 
         self._lock_bus(thread_id)

--- a/src/boss_bus/middleware/lock.py
+++ b/src/boss_bus/middleware/lock.py
@@ -1,0 +1,54 @@
+"""Enable automated logging within message handling."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from boss_bus.command_bus import Command
+from boss_bus.event_bus import Event
+from boss_bus.interface import Message, SpecificMessage
+from boss_bus.middleware.middleware import Middleware
+
+
+class LockingMessage(Message):
+    """A message that must be handled completely before other messages can be handled."""
+
+
+class LockingCommand(LockingMessage, Command):
+    """A form of command that must finish being handled before other commands can be executed."""
+
+
+class LockingEvent(LockingMessage, Event):
+    """A form of event that must finish being handled before other events can be dispatched."""
+
+
+class BusLocker(Middleware):
+    """Locks a MessageBus to prevent messages from being handled."""
+
+    def __init__(self):
+        """Creates a middleware class that can lock buses while messages are being handled."""
+        self.bus_locked: bool = False
+        self.queue: list[tuple[SpecificMessage, Callable[[SpecificMessage], Any]]] = []
+
+    def handle(
+        self,
+        message: SpecificMessage,
+        next_middleware: Callable[[SpecificMessage], Any],
+    ) -> Any:
+        """Locks a message bus while a message is being handled."""
+        print(self.bus_locked)
+        if self.bus_locked:
+            self.queue.append((message, next_middleware))
+            return None
+
+        if not isinstance(message, LockingMessage):
+            return next_middleware(message)
+
+        self.bus_locked = True
+        result = next_middleware(message)
+        self.bus_locked = False
+
+        for msg, handler in self.queue:
+            handler(msg)
+
+        return result

--- a/src/boss_bus/middleware/lock.py
+++ b/src/boss_bus/middleware/lock.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import os
+import threading
+import time
+from multiprocessing import Value
+from typing import TYPE_CHECKING, Any, Callable, Tuple
 
 from boss_bus.command_bus import Command
 from boss_bus.event_bus import Event
 from boss_bus.interface import Message, SpecificMessage
 from boss_bus.middleware.middleware import Middleware
 
+if TYPE_CHECKING:
+    from ctypes import c_ulong
+    from multiprocessing.sharedctypes import SynchronizedBase
+
 
 class LockingMessage(Message):
     """A message that must be handled completely before other messages can be handled."""
+
+    locking_message = True
 
 
 class LockingCommand(LockingMessage, Command):
@@ -22,13 +32,28 @@ class LockingEvent(LockingMessage, Event):
     """A form of event that must finish being handled before other events can be dispatched."""
 
 
+def get_thread_id() -> int:
+    """Return an ID representing the current process & thread."""
+    return int(str(os.getpid()) + str(threading.get_ident()))
+
+
+MessageHandlerTuple = Tuple[SpecificMessage, Callable[[SpecificMessage], Any]]
+
+
 class BusLocker(Middleware):
     """Locks a MessageBus to prevent messages from being handled."""
 
-    def __init__(self):
-        """Creates a middleware class that can lock buses while messages are being handled."""
-        self.bus_locked: bool = False
-        self.queue: list[tuple[SpecificMessage, Callable[[SpecificMessage], Any]]] = []
+    message_id: str = "locking_message"
+
+    def __init__(self, timeout: float = 5):
+        """Creates a middleware class that can lock buses while messages are being handled.
+
+        timeout sets the maximum time that a message will be paused for.
+        After this, the lock will be ignored and handling will continue.
+        """
+        self.timeout = timeout
+        self.locking_thread: SynchronizedBase[c_ulong] = Value("L", 0)
+        self.queue: list[MessageHandlerTuple[Any]] = []
 
     def handle(
         self,
@@ -36,19 +61,52 @@ class BusLocker(Middleware):
         next_middleware: Callable[[SpecificMessage], Any],
     ) -> Any:
         """Locks a message bus while a message is being handled."""
-        print(self.bus_locked)
-        if self.bus_locked:
-            self.queue.append((message, next_middleware))
-            return None
+        thread_id = get_thread_id()
 
-        if not isinstance(message, LockingMessage):
+        if self.bus_locked:
+            if self._in_locking_thread(thread_id):
+                self._postpone_handling(message, next_middleware)
+                return None
+
+            self._wait_for_unlock()
+
+        if not getattr(message, self.message_id, False):
             return next_middleware(message)
 
-        self.bus_locked = True
+        self._lock_bus(thread_id)
         result = next_middleware(message)
-        self.bus_locked = False
+        self._unlock_bus()
 
+        self._handle_queue()
+        return result
+
+    def _in_locking_thread(self, thread_id: int) -> bool:
+        return self.locking_thread.value == thread_id  # type: ignore[attr-defined, no-any-return]
+
+    def _postpone_handling(
+        self,
+        message: SpecificMessage,
+        next_middleware: Callable[[SpecificMessage], Any],
+    ) -> None:
+        self.queue.append((message, next_middleware))
+
+    def _wait_for_unlock(self) -> None:
+        timeout = time.time() + self.timeout
+        while self.bus_locked:
+            if time.time() > timeout:
+                break
+
+    def _lock_bus(self, thread_id: int) -> None:
+        self.locking_thread.value = thread_id  # type: ignore[attr-defined]
+
+    def _unlock_bus(self) -> None:
+        self.locking_thread.value = 0  # type: ignore[attr-defined]
+
+    def _handle_queue(self) -> None:
         for msg, handler in self.queue:
             handler(msg)
 
-        return result
+    @property
+    def bus_locked(self) -> bool:
+        """Whether new messages will be processed immediately."""
+        return self.locking_thread.value != 0  # type: ignore[attr-defined, no-any-return]

--- a/src/boss_bus/middleware/middleware.py
+++ b/src/boss_bus/middleware/middleware.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from functools import partial
 from typing import Any, Callable, Protocol, runtime_checkable
 
-from boss_bus.interface import SpecificMessage  # noqa: TCH001
+from boss_bus.interface import Message, SpecificMessage  # noqa: TCH001
 
 
 @runtime_checkable
 class Middleware(Protocol):
     """Performs actions before or after message handling."""
+
+    message_id: str
 
     def handle(
         self,
@@ -18,6 +20,10 @@ class Middleware(Protocol):
         next_middleware: Callable[[SpecificMessage], Any],
     ) -> Any:
         """Perform actions before or after message handling."""
+
+    def message_applicable(self, message: Message) -> bool:
+        """Should the current middleware do anything with this message."""
+        return getattr(message, self.message_id, False)
 
 
 def create_middleware_chain(

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -97,5 +97,5 @@ class ReturnTimeCommand(Command):
 class ReturnTimeCommandHandler(CommandHandler[ReturnTimeCommand]):
     def handle(self, command: ReturnTimeCommand) -> float:  # noqa: ARG002
         """Handle a test command."""
-        time.sleep(0.1)
+        time.sleep(0.05)
         return time.time()

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,6 +1,7 @@
 from boss_bus.command_bus import Command, CommandHandler
 from boss_bus.event_bus import Event
 from boss_bus.interface import SupportsHandle
+from boss_bus.message_bus import MessageBus
 
 
 class ExampleEvent(Event):
@@ -62,3 +63,26 @@ class ReturnCommandHandler(CommandHandler[ReturnCommand]):
     def handle(self, command: ReturnCommand) -> str:
         """Handle a test command."""
         return command.command_data
+
+
+class NestedCommand(Command):
+    """A command purely for use in tests."""
+
+    def __init__(self, command_data: str):
+        """Creates a command for tests."""
+        self.command_data = command_data
+
+
+class NestedCommandHandler(CommandHandler[NestedCommand]):
+    """A command handler purely for use in tests."""
+
+    def __init__(self, message_bus: MessageBus):
+        """Creates a command for tests."""
+        self.message_bus = message_bus
+
+    def handle(self, command: NestedCommand) -> str:
+        """Handle a test command."""
+        result: str = self.message_bus.execute(
+            ReturnCommand(command.command_data), ReturnCommandHandler()
+        )
+        return result

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,3 +1,5 @@
+import time
+
 from boss_bus.command_bus import Command, CommandHandler
 from boss_bus.event_bus import Event
 from boss_bus.interface import SupportsHandle
@@ -86,3 +88,13 @@ class NestedCommandHandler(CommandHandler[NestedCommand]):
             ReturnCommand(command.command_data), ReturnCommandHandler()
         )
         return result
+
+
+class ReturnTimeCommand(Command):
+    pass
+
+
+class ReturnTimeCommandHandler(CommandHandler[ReturnTimeCommand]):
+    def handle(self, command: ReturnTimeCommand) -> float:  # noqa: ARG002
+        """Handle a test command."""
+        return time.time()

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -97,4 +97,5 @@ class ReturnTimeCommand(Command):
 class ReturnTimeCommandHandler(CommandHandler[ReturnTimeCommand]):
     def handle(self, command: ReturnTimeCommand) -> float:  # noqa: ARG002
         """Handle a test command."""
+        time.sleep(0.1)
         return time.time()

--- a/tests/loader/examples.py
+++ b/tests/loader/examples.py
@@ -1,3 +1,9 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from boss_bus.message_bus import MessageBus
+
+
 class NoDeps:
     def __init__(self) -> None:
         self.output = "No dependencies loaded"
@@ -22,3 +28,8 @@ class CustomDeps:
         self.dep_one = dep_one
         self.dep_two = dep_two
         self.output = self.dep_one
+
+
+class BusDeps:
+    def __init__(self, bus: "MessageBus"):
+        self.bus = bus

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -47,3 +47,14 @@ class TestClassInstantiator:
         loaded_class = loader.load(BusDeps)
         assert isinstance(loaded_class, BusDeps)
         assert loaded_class.bus == bus
+
+    def test_message_bus_instance_can_be_added_to_instantiator(
+        self,
+    ) -> None:
+        loader = ClassInstantiator()
+        bus = MessageBus()
+        loader.add_dependency(bus)
+
+        loaded_class = loader.load(BusDeps)
+        assert isinstance(loaded_class, BusDeps)
+        assert loaded_class.bus == bus

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -42,7 +42,7 @@ class TestClassInstantiator:
         self,
     ) -> None:
         bus = MessageBus()
-        loader = ClassInstantiator(bus)
+        loader = ClassInstantiator([bus])
 
         loaded_class = loader.load(BusDeps)
         assert isinstance(loaded_class, BusDeps)

--- a/tests/loader/test_instantiator.py
+++ b/tests/loader/test_instantiator.py
@@ -1,5 +1,6 @@
 from boss_bus.loader.instantiator import ClassInstantiator
-from tests.loader.examples import LayeredDeps, NoDeps, SimpleDeps
+from boss_bus.message_bus import MessageBus
+from tests.loader.examples import BusDeps, LayeredDeps, NoDeps, SimpleDeps
 
 
 class TestClassInstantiator:
@@ -36,3 +37,13 @@ class TestClassInstantiator:
         assert isinstance(loaded_class, LayeredDeps)
         assert loaded_class.output == "Layered dependencies loaded"
         assert loaded_class.dep_one.output == "One dependency loaded"
+
+    def test_load_returns_message_bus_if_provided(
+        self,
+    ) -> None:
+        bus = MessageBus()
+        loader = ClassInstantiator(bus)
+
+        loaded_class = loader.load(BusDeps)
+        assert isinstance(loaded_class, BusDeps)
+        assert loaded_class.bus == bus

--- a/tests/loader/test_lagom_loader.py
+++ b/tests/loader/test_lagom_loader.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.loader.examples import CustomDeps, LayeredDeps, NoDeps
+from boss_bus.message_bus import MessageBus
+from tests.loader.examples import BusDeps, CustomDeps, LayeredDeps, NoDeps
 
 try:
     from lagom import Container
@@ -56,3 +57,15 @@ class TestClassInstantiator:
         loaded_class = loader.load(CustomDeps)
         assert isinstance(loaded_class, CustomDeps)
         assert loaded_class.output == "Class created"
+
+    def test_message_bus_instance_can_be_added_to_lagom(
+        self,
+    ) -> None:
+        container = Container()
+        loader = LagomLoader(container)
+        bus = MessageBus()
+        loader.add_dependency(bus)
+
+        loaded_class = loader.load(BusDeps)
+        assert isinstance(loaded_class, BusDeps)
+        assert loaded_class.bus == bus

--- a/tests/middleware/examples.py
+++ b/tests/middleware/examples.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from boss_bus.command_bus import CommandHandler
 from boss_bus.interface import SupportsHandle
-from boss_bus.middleware.log import LoggingCommand, LoggingEvent
+from boss_bus.middleware.lock import BusLocker, LockingCommand, LockingEvent
+from boss_bus.middleware.log import LoggingCommand, LoggingEvent, LoggingMessage
 
 
 class LogTestCommand(LoggingCommand):
@@ -43,3 +45,37 @@ class LogErrorEvent(LogTestEvent):
 class LoggingEventHandler(SupportsHandle):
     def handle(self, event: LogTestEvent) -> None:
         event.log_event_data()
+
+
+class LockTestCommand(LockingCommand):
+    pass
+
+
+class LockingCommandHandler(CommandHandler[LockTestCommand]):
+    def __init__(self, locker: BusLocker):
+        self.locker = locker
+
+    def handle(self, command: LockTestCommand) -> None:  # noqa: ARG002
+        def bus(c: LoggingMessage) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        logging.info("Pre-nested call")
+        self.locker.handle(LogTestCommand("Nested call"), bus)
+        logging.info("Post-nested call")
+
+
+class LockTestEvent(LockingEvent):
+    pass
+
+
+class LockingEventHandler(SupportsHandle):
+    def __init__(self, locker: BusLocker):
+        self.locker = locker
+
+    def handle(self, event: LockTestEvent) -> None:  # noqa: ARG002
+        def bus(e: LoggingMessage) -> Any:
+            LoggingEventHandler().handle(e)  # type: ignore[arg-type]
+
+        logging.info("Pre-nested call")
+        self.locker.handle(LogTestEvent("Nested call"), bus)
+        logging.info("Post-nested call")

--- a/tests/middleware/test_lock.py
+++ b/tests/middleware/test_lock.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+from tests.middleware.examples import (
+    LockingCommandHandler,
+    LockingEventHandler,
+    LockTestCommand,
+    LockTestEvent,
+    LoggingCommandHandler,
+    LogTestCommand,
+)
+
+from boss_bus.middleware.lock import BusLocker
+
+
+class TestLock:
+    def test_non_locking_command_does_not_lock_bus(self) -> None:
+        locker = BusLocker()
+        command = LogTestCommand("")
+
+        def bus(c: LogTestCommand) -> Any:
+            LoggingCommandHandler().handle(c)  # type: ignore[arg-type]
+
+        locker.handle(command, bus)
+
+        assert locker.bus_locked is False
+
+    def test_locking_command_postpones_nested_command(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        locker = BusLocker()
+        command = LockTestCommand()
+        caplog.set_level(logging.INFO)
+
+        def bus(c: LockTestCommand) -> Any:
+            LockingCommandHandler(locker).handle(c)  # type: ignore[arg-type]
+
+        locker.handle(command, bus)
+
+        assert "Pre-nested call" in caplog.record_tuples[0][2]
+        assert "Post-nested call" in caplog.record_tuples[1][2]
+        assert "Nested call" in caplog.record_tuples[2][2]
+
+    def test_locking_event_postpones_nested_event(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        locker = BusLocker()
+        event = LockTestEvent()
+        caplog.set_level(logging.INFO)
+
+        def bus(e: LockTestEvent) -> Any:
+            LockingEventHandler(locker).handle(e)  # type: ignore[arg-type]
+
+        locker.handle(event, bus)
+
+        assert "Pre-nested call" in caplog.record_tuples[0][2]
+        assert "Post-nested call" in caplog.record_tuples[1][2]
+        assert "Nested call" in caplog.record_tuples[2][2]

--- a/tests/middleware/test_lock.py
+++ b/tests/middleware/test_lock.py
@@ -80,7 +80,7 @@ class TestLock:
     def test_locked_bus_waits_to_execute_command_on_a_different_thread(self) -> None:
         locker = BusLocker()
         bus_unlock_time = multiprocessing.Value("d", 0)
-        command_1 = LockSleepCommand(0.2, bus_unlock_time)
+        command_1 = LockSleepCommand(0.4, bus_unlock_time)
         command_2 = ReturnTimeCommand()
 
         def bus_2(c: ReturnTimeCommand) -> Any:
@@ -100,7 +100,7 @@ class TestLock:
     def test_locked_bus_waits_to_execute_command_on_a_different_process(self) -> None:
         locker = BusLocker()
         bus_unlock_time = multiprocessing.Value("d", 0)
-        command_1 = LockSleepCommand(0.3, bus_unlock_time)
+        command_1 = LockSleepCommand(0.4, bus_unlock_time)
         command_2 = ReturnTimeCommand()
 
         def bus_2(c: ReturnTimeCommand) -> Any:
@@ -115,7 +115,7 @@ class TestLock:
         time.sleep(0.2)
 
         command_2_time = locker.handle(command_2, bus_2)
-        process_1.join(timeout=2)
+        process_1.join(timeout=3)
 
         assert bus_lock_time < bus_unlock_time.value < command_2_time  # type: ignore[attr-defined]
 

--- a/tests/middleware/test_lock.py
+++ b/tests/middleware/test_lock.py
@@ -57,9 +57,11 @@ class TestLock:
 
         locker.handle(command, bus)
 
-        assert "Pre-nested call" in caplog.record_tuples[0][2]
-        assert "Post-nested call" in caplog.record_tuples[1][2]
-        assert "Nested call" in caplog.record_tuples[2][2]
+        assert (
+            caplog.text.index("Pre-nested call")
+            < caplog.text.index("Post-nested call")
+            < caplog.text.index("Nested call")
+        )
 
     def test_locking_event_postpones_nested_event(
         self, caplog: LogCaptureFixture
@@ -73,9 +75,11 @@ class TestLock:
 
         locker.handle(event, bus)
 
-        assert "Pre-nested call" in caplog.record_tuples[0][2]
-        assert "Post-nested call" in caplog.record_tuples[1][2]
-        assert "Nested call" in caplog.record_tuples[2][2]
+        assert (
+            caplog.text.index("Pre-nested call")
+            < caplog.text.index("Post-nested call")
+            < caplog.text.index("Nested call")
+        )
 
     def test_locked_bus_waits_to_execute_command_on_a_different_thread(self) -> None:
         locker = BusLocker()

--- a/tests/middleware/test_log.py
+++ b/tests/middleware/test_log.py
@@ -91,7 +91,6 @@ class TestLog:
         with pytest.raises(Exception):  # noqa: B017, PT011
             logger.handle(command, bus)
 
-        print(caplog.record_tuples)
         assert len(caplog.record_tuples) == 2
         assert "Failed executing" in caplog.record_tuples[1][2]
 
@@ -106,6 +105,5 @@ class TestLog:
         with pytest.raises(Exception):  # noqa: B017, PT011
             logger.handle(event, bus)
 
-        print(caplog.record_tuples)
         assert len(caplog.record_tuples) == 2
         assert "Failed dispatching" in caplog.record_tuples[1][2]

--- a/tests/middleware/test_middleware_message_bus.py
+++ b/tests/middleware/test_middleware_message_bus.py
@@ -103,7 +103,7 @@ class TestMessageBusLogger:
     ) -> None:
         bus = MessageBus(middleware=[BusLocker()])
         bus_unlock_time = multiprocessing.Value("d", 0)
-        command_1 = LockSleepCommand(0.2, bus_unlock_time)
+        command_1 = LockSleepCommand(0.4, bus_unlock_time)
 
         thread_1 = threading.Thread(
             target=bus.execute, args=(command_1, LockSleepCommandHandler())
@@ -112,7 +112,7 @@ class TestMessageBusLogger:
         bus_lock_time = time.time()
 
         command_2_time = bus.execute(ReturnTimeCommand(), ReturnTimeCommandHandler())
-        thread_1.join(timeout=2)
+        thread_1.join(timeout=3)
 
         assert bus_lock_time < bus_unlock_time.value < command_2_time  # type: ignore[attr-defined]
 
@@ -121,7 +121,7 @@ class TestMessageBusLogger:
     ) -> None:
         bus = MessageBus(middleware=[BusLocker()])
         bus_unlock_time = multiprocessing.Value("d", 0)
-        command_1 = LockSleepCommand(0.3, bus_unlock_time)
+        command_1 = LockSleepCommand(0.4, bus_unlock_time)
 
         process_1 = multiprocessing.Process(
             target=bus.execute, args=(command_1, LockSleepCommandHandler())
@@ -132,6 +132,6 @@ class TestMessageBusLogger:
         time.sleep(0.2)
 
         command_2_time = bus.execute(ReturnTimeCommand(), ReturnTimeCommandHandler())
-        process_1.join(timeout=2)
+        process_1.join(timeout=3)
 
         assert bus_lock_time < bus_unlock_time.value < command_2_time  # type: ignore[attr-defined]

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -8,6 +8,8 @@ from boss_bus.message_bus import MessageBus
 from tests.examples import (
     ExampleEvent,
     ExampleEventHandler,
+    NestedCommand,
+    NestedCommandHandler,
     OtherEventHandler,
     PrintCommand,
     PrintCommandHandler,
@@ -151,3 +153,11 @@ class TestMessageBus:
         bus.deregister_event(ExampleEvent, [ExampleEventHandler])
 
         assert bus.has_handlers(ExampleEvent) == 1
+
+    def test_default_loader_loads_the_message_bus_as_a_dependency(self) -> None:
+        bus = MessageBus()
+        bus.register_command(NestedCommand, NestedCommandHandler)
+
+        result = bus.execute(NestedCommand("Nested"))
+
+        assert result == "Nested"


### PR DESCRIPTION
This adds a new piece of middleware which is capable of locking the message bus when a `LockingMessage` is passed for handling. Locking messages will lock the bus before being handled and then no other messages will be handled until the locking message has finished its actions. The wait during a lock is handled differently depending on whether the new message is in the same thread and process as the locking message:
- Latter message is in a different thread or process to the former: Latter message will be paused until the bus is unlocked or a timeout has been reached. A default timeout is set by the `BusLocker`.
- Latter and former message are in the same thread and process: The latter message is added to a queue and returns None. The queue is then handled when the bus is unlocked. In practice, this will be nested messages. If the bus paused execution, the first message would never finish. Commands handlers nested inside a locking message are not able to return a value.

If an asynchronous message bus is created, the process for messages in the same thread may need to be revisited as this currently cannot handle messages running inside an event loop.

It is preferable for this middleware to go at the start of the stack as this allows it to prevent any further action when the bus is locked.

Other changes:
- Change middleware applicability checks to use an attribute rather than `isinstance`